### PR TITLE
feat: add multi-agent phase components

### DIFF
--- a/components/multi-agent/README.md
+++ b/components/multi-agent/README.md
@@ -1,0 +1,14 @@
+# Multi-Agent Conversational Components
+
+Reusable UI elements to render the results of each phase of the YSH Pre-Sale
+multi-agent flow. Each phase is represented with an icon, label and container
+that can display streaming content.
+
+```tsx
+<PhaseMessage phase="analysis" isLoading>
+  O consumo médio mensal é de 450 kWh.
+</PhaseMessage>
+```
+
+The component library is designed to be extended with additional phases or used
+in other conversational interfaces.

--- a/components/multi-agent/index.ts
+++ b/components/multi-agent/index.ts
@@ -1,0 +1,2 @@
+export * from './phase';
+export * from './phase-message';

--- a/components/multi-agent/phase-message.tsx
+++ b/components/multi-agent/phase-message.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+import { AgentPhase, phaseDetails, phaseStyles } from './phase';
+
+interface PhaseMessageProps {
+  phase: AgentPhase;
+  children: ReactNode;
+  isLoading?: boolean;
+}
+
+export function PhaseMessage({
+  phase,
+  children,
+  isLoading,
+}: PhaseMessageProps) {
+  const { label, icon: Icon } = phaseDetails[phase];
+  const style = phaseStyles[phase];
+
+  return (
+    <div className="flex items-start gap-2 py-2">
+      <div
+        className={cn(
+          'flex items-center justify-center rounded-full border p-1 size-6',
+          style,
+        )}
+      >
+        <Icon size={14} />
+      </div>
+      <div className="flex-1">
+        <span className="text-xs font-semibold">{label}</span>
+        <div className="mt-1 rounded-md bg-muted p-2 text-sm">
+          {children}
+          {isLoading && (
+            <motion.span
+              className="ml-2 inline-block animate-pulse"
+              aria-label="loading"
+            >
+              ...
+            </motion.span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/multi-agent/phase.ts
+++ b/components/multi-agent/phase.ts
@@ -1,0 +1,28 @@
+import type { LucideIcon } from 'lucide-react';
+import { Search, ScanLine, BarChart3, Ruler, Handshake } from 'lucide-react';
+
+export type AgentPhase =
+  | 'investigation'
+  | 'detection'
+  | 'analysis'
+  | 'sizing'
+  | 'recommendation';
+
+export const phaseDetails: Record<
+  AgentPhase,
+  { label: string; icon: LucideIcon }
+> = {
+  investigation: { label: 'Investigação', icon: Search },
+  detection: { label: 'Detecção', icon: ScanLine },
+  analysis: { label: 'Análise', icon: BarChart3 },
+  sizing: { label: 'Dimensionamento', icon: Ruler },
+  recommendation: { label: 'Recomendação', icon: Handshake },
+};
+
+export const phaseStyles: Record<AgentPhase, string> = {
+  investigation: 'text-blue-600 border-blue-600',
+  detection: 'text-amber-600 border-amber-600',
+  analysis: 'text-indigo-600 border-indigo-600',
+  sizing: 'text-green-600 border-green-600',
+  recommendation: 'text-pink-600 border-pink-600',
+};


### PR DESCRIPTION
## Summary
- add phase definitions for multi-agent workflow with icons and styles
- implement `PhaseMessage` component to show phase outputs and loading state
- document multi-agent conversational components

## Testing
- `pnpm exec biome format components/multi-agent/phase.ts components/multi-agent/phase-message.tsx components/multi-agent/index.ts components/multi-agent/README.md --write`
- `pnpm test` *(fails: 34 did not run; serving HTML report at http://localhost:9323)*

------
https://chatgpt.com/codex/tasks/task_e_68ba37e424ac83329cde9894023b513e