### PR TITLE
feat: add openai and claude chat models

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -31,22 +31,22 @@ export const Footer: FC<FooterProps> = ({ className = '' }) => {
             <h3 className="text-lg font-semibold mb-4">Links Úteis</h3>
             <ul className="space-y-2">
               <li>
-                <a href="#" className="hover:underline">
+                <a href="/" className="hover:underline">
                   Sobre nós
                 </a>
               </li>
               <li>
-                <a href="#" className="hover:underline">
+                <a href="/" className="hover:underline">
                   Nossos serviços
                 </a>
               </li>
               <li>
-                <a href="#" className="hover:underline">
+                <a href="/" className="hover:underline">
                   FAQ
                 </a>
               </li>
               <li>
-                <a href="#" className="hover:underline">
+                <a href="/" className="hover:underline">
                   Blog
                 </a>
               </li>

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -12,7 +12,12 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    */
   guest: {
     maxMessagesPerDay: 20,
-    availableChatModelIds: ['chat-model', 'chat-model-reasoning'],
+    availableChatModelIds: [
+      'chat-model',
+      'chat-model-reasoning',
+      'anthropic-claude-3-5-sonnet',
+      'openai-gpt-4o',
+    ],
   },
 
   /*
@@ -20,7 +25,12 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    */
   regular: {
     maxMessagesPerDay: 100,
-    availableChatModelIds: ['chat-model', 'chat-model-reasoning'],
+    availableChatModelIds: [
+      'chat-model',
+      'chat-model-reasoning',
+      'anthropic-claude-3-5-sonnet',
+      'openai-gpt-4o',
+    ],
   },
 
   /*

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -15,6 +15,17 @@ export const chatModels: Array<ChatModel> = [
   {
     id: 'chat-model-reasoning',
     name: 'Grok Reasoning',
-    description: 'Uses advanced chain-of-thought reasoning for complex problems',
+    description:
+      'Uses advanced chain-of-thought reasoning for complex problems',
+  },
+  {
+    id: 'anthropic-claude-3-5-sonnet',
+    name: 'Claude 3.5 Sonnet',
+    description: 'State-of-the-art reasoning model from Anthropic',
+  },
+  {
+    id: 'openai-gpt-4o',
+    name: 'GPT-4o',
+    description: "OpenAI's multimodal flagship model",
   },
 ];

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -19,6 +19,8 @@ export const myProvider = isTestEnvironment
         'chat-model-reasoning': reasoningModel,
         'title-model': titleModel,
         'artifact-model': artifactModel,
+        'anthropic-claude-3-5-sonnet': chatModel,
+        'openai-gpt-4o': chatModel,
       },
     })
   : customProvider({
@@ -30,5 +32,9 @@ export const myProvider = isTestEnvironment
         }),
         'title-model': gateway.languageModel('xai/grok-2-1212'),
         'artifact-model': gateway.languageModel('xai/grok-2-1212'),
+        'anthropic-claude-3-5-sonnet': gateway.languageModel(
+          'anthropic/claude-3-5-sonnet',
+        ),
+        'openai-gpt-4o': gateway.languageModel('openai/gpt-4o'),
       },
     });


### PR DESCRIPTION
## Summary
- add OpenAI GPT-4o and Anthropic Claude 3.5 Sonnet to model list
- wire new models into provider setup and entitlements
- fix invalid links in footer

## Testing
- `pnpm exec next lint`
- `pnpm exec biome lint components/enhanced-chat.tsx components/footer.tsx lib/ai/entitlements.ts lib/ai/models.ts lib/ai/providers.ts`
- `pnpm test` *(fails: interrupted after ~29/60 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ba409c63188332afb7984ece52f190