### PR TITLE
feat: add canvas board components

### DIFF
--- a/apps/web/components/canvas/CanvasBoard.tsx
+++ b/apps/web/components/canvas/CanvasBoard.tsx
@@ -1,0 +1,112 @@
+import type { ReactNode } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { localStorageProvider, type StorageProvider } from '@/apps/web/lib/canvas/storage';
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+interface CanvasBoardProps {
+  children: ReactNode | ReactNode[];
+  storageKey?: string;
+  storage?: StorageProvider;
+}
+
+export function CanvasBoard({
+  children,
+  storageKey = 'canvas-layout',
+  storage = localStorageProvider,
+}: CanvasBoardProps) {
+  const [layout, setLayout] = useState<Record<string, Position>>({});
+  const [scale, setScale] = useState(1);
+  const draggingId = useRef<string | null>(null);
+  const lastPos = useRef({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const saved = storage.getItem<Record<string, Position>>(storageKey);
+    if (saved) setLayout(saved);
+  }, [storage, storageKey]);
+
+  useEffect(() => {
+    storage.setItem(storageKey, layout);
+  }, [layout, storage, storageKey]);
+
+  const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (!e.ctrlKey) return;
+    e.preventDefault();
+    setScale((s) => {
+      const next = s - e.deltaY * 0.001;
+      return Math.min(Math.max(next, 0.5), 2);
+    });
+  };
+
+  const onPointerDown = (id: string, e: React.PointerEvent) => {
+    draggingId.current = id;
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    const id = draggingId.current;
+    if (!id) return;
+    const delta = {
+      x: e.clientX - lastPos.current.x,
+      y: e.clientY - lastPos.current.y,
+    };
+    lastPos.current = { x: e.clientX, y: e.clientY };
+    setLayout((l) => {
+      const prev = l[id] ?? { x: 0, y: 0 };
+      return { ...l, [id]: { x: prev.x + delta.x, y: prev.y + delta.y } };
+    });
+  };
+
+  const onPointerUp = () => {
+    const id = draggingId.current;
+    if (!id) return;
+    draggingId.current = null;
+    setLayout((l) => {
+      const pos = l[id];
+      const snapped = {
+        x: Math.round(pos.x / 20) * 20,
+        y: Math.round(pos.y / 20) * 20,
+      };
+      return { ...l, [id]: snapped };
+    });
+  };
+
+  const nodes = Array.isArray(children) ? children : [children];
+
+  return (
+    <div
+      className="relative w-full h-full overflow-hidden"
+      onWheel={handleWheel}
+      style={{
+        backgroundSize: `${20 * scale}px ${20 * scale}px`,
+        backgroundImage:
+          'linear-gradient(to right, #eee 1px, transparent 1px), linear-gradient(to bottom, #eee 1px, transparent 1px)',
+        transform: `scale(${scale})`,
+        transformOrigin: '0 0',
+      }}
+    >
+      {nodes.map((child: any) => {
+        const id = child.props.id;
+        const pos = layout[id] ?? { x: 0, y: 0 };
+        return (
+          <div
+            key={id}
+            style={{
+              position: 'absolute',
+              transform: `translate(${pos.x}px, ${pos.y}px)`,
+            }}
+            onPointerDown={(e) => onPointerDown(id, e)}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+          >
+            {child}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/canvas/Card.tsx
+++ b/apps/web/components/canvas/Card.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { CardToolbar } from './CardToolbar';
+
+interface CardProps {
+  id: string;
+  title: string;
+  tags?: string[];
+  avatarUrl?: string;
+  timestamp?: Date;
+  onPin?: () => void;
+  onCompare?: () => void;
+  onExport?: (format: string) => void;
+  onRun?: () => void;
+  children?: ReactNode;
+}
+
+export function Card({
+  id,
+  title,
+  tags = [],
+  avatarUrl,
+  timestamp,
+  onPin,
+  onCompare,
+  onExport,
+  onRun,
+  children,
+}: CardProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <div id={id} className="border rounded bg-white shadow-md w-80">
+      <div className="flex items-center justify-between p-2 border-b">
+        <div className="flex items-center gap-2">
+          {avatarUrl ? (
+            <img src={avatarUrl} alt="" className="w-6 h-6 rounded-full" />
+          ) : null}
+          <div className="flex flex-col">
+            <span className="font-medium">{title}</span>
+            {tags.length > 0 && (
+              <span className="text-xs text-gray-500">{tags.join(', ')}</span>
+            )}
+          </div>
+        </div>
+        <div className="relative flex items-center gap-1">
+          {timestamp && (
+            <span className="text-xs text-gray-400">
+              {timestamp.toLocaleTimeString()}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => setMenuOpen((o) => !o)}
+            aria-label="menu"
+          >
+            ⋮
+          </button>
+          {menuOpen && (
+            <div className="absolute right-0 mt-2 bg-white border rounded shadow-md z-10">
+              <button
+                type="button"
+                className="block px-2 py-1 w-full text-left"
+                onClick={onPin}
+              >
+                Pin
+              </button>
+              <button
+                type="button"
+                className="block px-2 py-1 w-full text-left"
+                onClick={onCompare}
+              >
+                Compare
+              </button>
+              <button
+                type="button"
+                className="block px-2 py-1 w-full text-left"
+                onClick={() => onExport?.('json')}
+              >
+                Export
+              </button>
+              <button
+                type="button"
+                className="block px-2 py-1 w-full text-left"
+                onClick={onRun}
+              >
+                Run
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="p-2">{children}</div>
+      <CardToolbar
+        onRecalculate={onRun}
+        onDuplicate={() => {}}
+        onExport={onExport}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/canvas/CardToolbar.tsx
+++ b/apps/web/components/canvas/CardToolbar.tsx
@@ -1,0 +1,40 @@
+interface CardToolbarProps {
+  onRecalculate?: () => void;
+  onDuplicate?: () => void;
+  onExport?: (format: 'png' | 'pdf' | 'json' | 'csv') => void;
+}
+
+const formats: Array<'png' | 'pdf' | 'json' | 'csv'> = [
+  'png',
+  'pdf',
+  'json',
+  'csv',
+];
+
+export function CardToolbar({ onRecalculate, onDuplicate, onExport }: CardToolbarProps) {
+  return (
+    <div className="flex justify-end gap-2 p-2 border-t bg-gray-50 text-xs">
+      <button type="button" onClick={onRecalculate}>
+        Recalcular
+      </button>
+      <button type="button" onClick={onDuplicate}>
+        Duplicar
+      </button>
+      <div className="relative">
+        <span>Export</span>
+        <div className="absolute right-0 bg-white border rounded shadow-md">
+          {formats.map((fmt) => (
+            <button
+              key={fmt}
+              type="button"
+              className="block px-2 py-1 w-full text-left"
+              onClick={() => onExport?.(fmt)}
+            >
+              {fmt.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/canvas/CommentThread.tsx
+++ b/apps/web/components/canvas/CommentThread.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+
+interface Comment {
+  id: string;
+  author: string;
+  text: string;
+  createdAt: Date;
+}
+
+interface CommentThreadProps {
+  comments: Comment[];
+  onAdd?: (text: string) => void;
+}
+
+export function CommentThread({ comments, onAdd }: CommentThreadProps) {
+  const [text, setText] = useState('');
+
+  const handleAdd = () => {
+    if (!text.trim()) return;
+    onAdd?.(text);
+    setText('');
+  };
+
+  return (
+    <div className="space-y-2">
+      <ul className="space-y-2">
+        {comments.map((c) => (
+          <li key={c.id} className="text-sm">
+            <span className="font-medium">{c.author}</span>: {c.text}
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          className="flex-1 border rounded px-2 py-1"
+        />
+        <button type="button" onClick={handleAdd}>
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/canvas/CompareView.tsx
+++ b/apps/web/components/canvas/CompareView.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+interface CompareViewProps {
+  left: ReactNode;
+  right: ReactNode;
+}
+
+export function CompareView({ left, right }: CompareViewProps) {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      <div className="border rounded overflow-auto">{left}</div>
+      <div className="border rounded overflow-auto">{right}</div>
+    </div>
+  );
+}

--- a/apps/web/components/canvas/VersionTimeline.tsx
+++ b/apps/web/components/canvas/VersionTimeline.tsx
@@ -1,0 +1,35 @@
+interface Version {
+  id: string;
+  label: string;
+}
+
+interface VersionTimelineProps {
+  versions: Version[];
+  onSelect?: (v: Version) => void;
+  onBranch?: (v: Version) => void;
+}
+
+export function VersionTimeline({ versions, onSelect, onBranch }: VersionTimelineProps) {
+  return (
+    <ol className="p-2 space-y-1 text-sm">
+      {versions.map((v) => (
+        <li key={v.id} className="flex items-center gap-2">
+          <button
+            type="button"
+            className="underline"
+            onClick={() => onSelect?.(v)}
+          >
+            {v.label}
+          </button>
+          <button
+            type="button"
+            className="text-xs"
+            onClick={() => onBranch?.(v)}
+          >
+            branch
+          </button>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/web/lib/canvas/artifacts.ts
+++ b/apps/web/lib/canvas/artifacts.ts
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react';
+
+export interface Artifact {
+  id: string;
+  type: string;
+  data: unknown;
+  createdAt: Date;
+}
+
+export interface ArtifactRef {
+  id: string;
+  version: number;
+}
+
+export type ArtifactRenderer = (artifact: Artifact) => ReactNode;
+
+const registry = new Map<string, ArtifactRenderer>();
+
+export function registerRenderer(type: string, renderer: ArtifactRenderer) {
+  registry.set(type, renderer);
+}
+
+export function getRenderer(type: string) {
+  return registry.get(type);
+}
+
+export function renderArtifact(artifact: Artifact): ReactNode {
+  const renderer = registry.get(artifact.type);
+  return renderer ? renderer(artifact) : null;
+}
+

--- a/apps/web/lib/canvas/storage.ts
+++ b/apps/web/lib/canvas/storage.ts
@@ -1,0 +1,24 @@
+export interface StorageProvider {
+  getItem<T>(key: string): T | null;
+  setItem<T>(key: string, value: T): void;
+}
+
+export const localStorageProvider: StorageProvider = {
+  getItem: (key) => {
+    if (typeof window === 'undefined') return null;
+    try {
+      const raw = window.localStorage.getItem(key);
+      return raw ? (JSON.parse(raw) as unknown) : null;
+    } catch {
+      return null;
+    }
+  },
+  setItem: (key, value) => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ignore
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- scaffold CanvasBoard with draggable cards and zoom persistence
- introduce Card, CardToolbar, VersionTimeline, CompareView, and CommentThread primitives
- add artifact registry and basic storage provider for canvas layouts

## Testing
- `pnpm lint`
- `pnpm test` *(generates HTML report; tests did not run in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68ba44fa90588332981e8403bfefa5db