### PR TITLE
feat: add persona modes with gated UI

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
 import { AccessibilityProvider } from '@/lib/accessibility/context';
 import { AccessibilityListener } from '@/components/accessibility-listener';
+import { PersonaProvider } from '@/lib/persona/context';
 
 import './globals.css';
 import '../styles/accessibility.css';
@@ -86,10 +87,12 @@ export default async function RootLayout({
         >
           <Toaster position="top-center" />
           <AccessibilityProvider>
-            <SessionProvider>
-              {children}
-              <AccessibilityListener />
-            </SessionProvider>
+            <PersonaProvider>
+              <SessionProvider>
+                {children}
+                <AccessibilityListener />
+              </SessionProvider>
+            </PersonaProvider>
           </AccessibilityProvider>
         </ThemeProvider>
       </body>

--- a/app/persona/page.tsx
+++ b/app/persona/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { PersonaSwitcher } from "@/components/persona-switcher";
+import { FeatureGate } from "@/components/feature-gate";
+import {
+  GuidedWizardOverlay,
+  SavingsSlider,
+  GoalPicker,
+  FinancingPicker,
+  AppointmentScheduler,
+  ConsentManager,
+} from "@/components/persona/owner";
+import {
+  SpecLibrary,
+  LayoutOptimizerPanel,
+  ConstraintsEditor,
+  TariffSelector,
+  PricingRules,
+  ComplianceChecklist,
+  DataSourceSelector,
+  BatchRunner,
+} from "@/components/persona/integrator";
+import { usePersona } from "@/lib/persona/context";
+
+export default function PersonaPage() {
+  const { mode } = usePersona();
+  return (
+    <main className="p-4 space-y-4">
+      <PersonaSwitcher />
+      {mode === "owner" ? (
+        <div className="space-y-3">
+          <FeatureGate permission="owner">
+            <GuidedWizardOverlay />
+          </FeatureGate>
+          <FeatureGate permission="owner">
+            <SavingsSlider />
+          </FeatureGate>
+          <FeatureGate permission="owner">
+            <GoalPicker />
+          </FeatureGate>
+          <FeatureGate permission="owner">
+            <FinancingPicker />
+          </FeatureGate>
+          <FeatureGate permission="owner">
+            <AppointmentScheduler />
+          </FeatureGate>
+          <FeatureGate permission="owner">
+            <ConsentManager />
+          </FeatureGate>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <FeatureGate permission="integrator">
+            <SpecLibrary />
+          </FeatureGate>
+          <FeatureGate permission="integrator">
+            <LayoutOptimizerPanel />
+          </FeatureGate>
+          <FeatureGate permission="integrator">
+            <ConstraintsEditor />
+          </FeatureGate>
+          <FeatureGate permission="integrator">
+            <TariffSelector />
+          </FeatureGate>
+          <FeatureGate permission="integrator">
+            <PricingRules />
+          </FeatureGate>
+          <FeatureGate permission="integrator">
+            <ComplianceChecklist />
+          </FeatureGate>
+          <FeatureGate permission="integrator">
+            <DataSourceSelector />
+          </FeatureGate>
+          <FeatureGate permission="integrator" flag="batch">
+            <BatchRunner />
+          </FeatureGate>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/sidebar';
 import Link from 'next/link';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import { PersonaSwitcher } from '@/components/persona-switcher';
 
 export function AppSidebar({ user }: { user: User | undefined }) {
   const router = useRouter();
@@ -61,7 +62,12 @@ export function AppSidebar({ user }: { user: User | undefined }) {
       <SidebarContent>
         <SidebarHistory user={user} />
       </SidebarContent>
-      <SidebarFooter>{user && <SidebarUserNav user={user} />}</SidebarFooter>
+      <SidebarFooter>
+        <div className="p-2 space-y-2">
+          <PersonaSwitcher />
+          {user && <SidebarUserNav user={user} />}
+        </div>
+      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/components/feature-gate.tsx
+++ b/components/feature-gate.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import React from "react";
+import { usePersona } from "@/lib/persona/context";
+
+export function FeatureGate({
+  permission,
+  flag,
+  children,
+}: {
+  permission?: string;
+  flag?: string;
+  children: React.ReactNode;
+}) {
+  const { hasPermission, isEnabled } = usePersona();
+  if (permission && !hasPermission(permission)) return null;
+  if (flag && !isEnabled(flag)) return null;
+  return <>{children}</>;
+}

--- a/components/persona-switcher.tsx
+++ b/components/persona-switcher.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { usePersona, type PersonaMode } from "@/lib/persona/context";
+
+export function PersonaSwitcher() {
+  const { mode, setMode } = usePersona();
+  return (
+    <div className="flex flex-col gap-2 w-48">
+      <Label htmlFor="persona-mode">Persona Mode</Label>
+      <Select
+        value={mode}
+        onValueChange={(val) => setMode(val as PersonaMode)}
+      >
+        <SelectTrigger id="persona-mode">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="owner">Owner</SelectItem>
+          <SelectItem value="integrator">Integrator</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/components/persona/integrator.tsx
+++ b/components/persona/integrator.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+export function SpecLibrary() {
+  return <div className="p-2 border rounded">Spec Library</div>;
+}
+
+export function LayoutOptimizerPanel() {
+  return <div className="p-2 border rounded">Layout Optimizer Panel</div>;
+}
+
+export function ConstraintsEditor() {
+  return <div className="p-2 border rounded">Constraints Editor</div>;
+}
+
+export function TariffSelector() {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor="tariff">Tariff</label>
+      <select id="tariff" className="border p-1 rounded">
+        <option>Residential</option>
+        <option>Commercial</option>
+      </select>
+    </div>
+  );
+}
+
+export function PricingRules() {
+  return <div className="p-2 border rounded">Pricing Rules</div>;
+}
+
+export function ComplianceChecklist() {
+  return <div className="p-2 border rounded">Compliance Checklist</div>;
+}
+
+export function DataSourceSelector() {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor="data-source">Data Source</label>
+      <select id="data-source" className="border p-1 rounded">
+        <option>API</option>
+        <option>CSV</option>
+      </select>
+    </div>
+  );
+}
+
+export function BatchRunner() {
+  return <button className="border p-2 rounded">Run Batch</button>;
+}

--- a/components/persona/owner.tsx
+++ b/components/persona/owner.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+export function GuidedWizardOverlay() {
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Guided Wizard" className="p-4 border rounded-md">
+      Guided Wizard Overlay
+    </div>
+  );
+}
+
+export function SavingsSlider() {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor="savings">Savings</label>
+      <input id="savings" type="range" min={0} max={100} />
+    </div>
+  );
+}
+
+export function GoalPicker() {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor="goal">Goal</label>
+      <select id="goal" className="border p-1 rounded">
+        <option>Retirement</option>
+        <option>Education</option>
+      </select>
+    </div>
+  );
+}
+
+export function FinancingPicker() {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor="financing">Financing</label>
+      <select id="financing" className="border p-1 rounded">
+        <option>Cash</option>
+        <option>Loan</option>
+      </select>
+    </div>
+  );
+}
+
+export function AppointmentScheduler() {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor="appointment">Appointment Date</label>
+      <input id="appointment" type="date" className="border p-1 rounded" />
+    </div>
+  );
+}
+
+export function ConsentManager() {
+  return (
+    <div className="flex items-center gap-2">
+      <input id="consent" type="checkbox" />
+      <label htmlFor="consent">I agree to the terms</label>
+    </div>
+  );
+}

--- a/lib/persona/context.tsx
+++ b/lib/persona/context.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type PersonaMode = "owner" | "integrator";
+
+interface PersonaContextValue {
+  mode: PersonaMode;
+  permissions: string[];
+  featureFlags: Record<string, boolean>;
+  setMode: (mode: PersonaMode) => void;
+  hasPermission: (perm: string) => boolean;
+  isEnabled: (flag: string) => boolean;
+}
+
+const PersonaContext = createContext<PersonaContextValue | undefined>(undefined);
+
+const PERMISSIONS: Record<PersonaMode, string[]> = {
+  owner: ["owner"],
+  integrator: ["integrator"],
+};
+
+const FLAGS: Record<PersonaMode, Record<string, boolean>> = {
+  owner: { wizard: true },
+  integrator: { batch: true, advanced: true },
+};
+
+export function PersonaProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setMode] = useState<PersonaMode>("owner");
+  const [featureFlags, setFeatureFlags] = useState<Record<string, boolean>>(FLAGS["owner"]);
+
+  useEffect(() => {
+    const storedMode = window.localStorage.getItem("persona-mode") as PersonaMode | null;
+    if (storedMode) {
+      setMode(storedMode);
+      setFeatureFlags(FLAGS[storedMode]);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem("persona-mode", mode);
+    setFeatureFlags(FLAGS[mode]);
+  }, [mode]);
+
+  const value: PersonaContextValue = {
+    mode,
+    permissions: PERMISSIONS[mode],
+    featureFlags,
+    setMode,
+    hasPermission: (perm) => PERMISSIONS[mode].includes(perm),
+    isEnabled: (flag) => Boolean(featureFlags[flag]),
+  };
+
+  return <PersonaContext.Provider value={value}>{children}</PersonaContext.Provider>;
+}
+
+export function usePersona() {
+  const ctx = useContext(PersonaContext);
+  if (!ctx) throw new Error("usePersona must be used within PersonaProvider");
+  return ctx;
+}
+

--- a/tests/e2e/__snapshots__/persona.test.ts/persona-integrator.txt
+++ b/tests/e2e/__snapshots__/persona.test.ts/persona-integrator.txt
@@ -1,0 +1,1 @@
+Persona ModeIntegratorSpec LibraryLayout Optimizer PanelConstraints EditorTariffResidentialCommercialPricing RulesCompliance ChecklistData SourceAPICSVRun Batch

--- a/tests/e2e/__snapshots__/persona.test.ts/persona-owner.txt
+++ b/tests/e2e/__snapshots__/persona.test.ts/persona-owner.txt
@@ -1,0 +1,1 @@
+Persona ModeOwnerGuided Wizard OverlaySavingsGoalRetirementEducationFinancingCashLoanAppointment DateI agree to the terms

--- a/tests/e2e/persona.test.ts
+++ b/tests/e2e/persona.test.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+const SNAPSHOT_PATH = 'persona';
+
+test('persona modes render expected UI', async ({ page }) => {
+  await page.goto('/persona');
+  await expect(page.getByRole('dialog', { name: 'Guided Wizard' })).toBeVisible();
+  expect(await page.textContent('main')).toMatchSnapshot(`${SNAPSHOT_PATH}-owner.txt`);
+
+  await page.getByLabel('Persona Mode').click();
+  await page.getByText('Integrator').click();
+  await expect(page.getByText('Spec Library')).toBeVisible();
+  expect(await page.textContent('main')).toMatchSnapshot(`${SNAPSHOT_PATH}-integrator.txt`);
+});


### PR DESCRIPTION
## Summary
- add persona context with owner and integrator modes
- gate UI features with permissions and feature flags
- provide persona switcher and demo page with snapshots

## Testing
- `pnpm lint`
- `pnpm test tests/e2e/persona.test.ts -- --update-snapshots` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba48d007388332b5f3cbbecae7ca95