### PR TITLE
feat: orchestrate journey phases with navigation hooks

### DIFF
--- a/app/journey/[phase]/page.tsx
+++ b/app/journey/[phase]/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { PhaseGuard } from '@/apps/web/lib/journey/guard';
+import { usePhase, useJourneyActions } from '@/apps/web/lib/journey/hooks';
+import type { Phase } from '@/apps/web/lib/journey/map';
+
+export default function Page({ params }: { params: { phase: Phase } }) {
+  return (
+    <PhaseGuard phase={params.phase}>
+      <PhaseView />
+    </PhaseGuard>
+  );
+}
+
+function PhaseView() {
+  const phase = usePhase();
+  const { next, prev, skip, reset } = useJourneyActions();
+  return (
+    <div>
+      <h1>{phase}</h1>
+      <button id="prev" onClick={prev}>
+        Prev
+      </button>
+      <button id="next" onClick={next}>
+        Next
+      </button>
+      <button id="skip" onClick={() => skip('Recommendation')}>
+        Skip
+      </button>
+      <button id="reset" onClick={reset}>
+        Reset
+      </button>
+    </div>
+  );
+}

--- a/app/journey/layout.tsx
+++ b/app/journey/layout.tsx
@@ -1,0 +1,9 @@
+import { JourneyProvider } from '@/apps/web/lib/journey/context';
+
+export default function Layout({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}) {
+  return <JourneyProvider>{children}</JourneyProvider>;
+}

--- a/app/journey/page.tsx
+++ b/app/journey/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+import { phases } from '@/apps/web/lib/journey/map';
+
+export default function Page() {
+  redirect(`/journey/${phases[0]}`);
+}

--- a/apps/web/lib/journey/context.tsx
+++ b/apps/web/lib/journey/context.tsx
@@ -1,0 +1,94 @@
+'use client';
+import { createContext, useEffect, useRef, useState } from 'react';
+import { phases, journeyMap, type Phase } from './map';
+
+interface Telemetry {
+  start: number;
+  end?: number;
+  errors: string[];
+}
+
+interface JourneyContextValue {
+  phase: Phase;
+  telemetry: Record<Phase, Telemetry>;
+  next: () => void;
+  prev: () => void;
+  skip: (p: Phase) => void;
+  reset: () => void;
+}
+
+export const JourneyContext = createContext<JourneyContextValue | undefined>(
+  undefined,
+);
+
+export function JourneyProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [phase, setPhase] = useState<Phase>(phases[0]);
+
+  const telemetryRef = useRef<Record<Phase, Telemetry>>(
+    Object.fromEntries(phases.map((p) => [p, { start: 0, errors: [] }])) as Record<
+      Phase,
+      Telemetry
+    >,
+  );
+
+  const preloadPhase = async (p: Phase) => {
+  const { cards, viewers } = journeyMap[p];
+  for (const asset of [...cards, ...viewers]) {
+    try {
+      // dynamic import using data URL to simulate preloading
+      // @ts-ignore
+      await import(`data:text/javascript,export default \"${asset}\"`);
+    } catch (e) {
+      telemetryRef.current[p].errors.push(String(e));
+    }
+  }
+};
+
+  useEffect(() => {
+    const t = telemetryRef.current;
+    const now = Date.now();
+    if (!t[phase].start) t[phase].start = now;
+    preloadPhase(phase);
+    // expose for tests
+    // @ts-ignore
+    window.__journey = { phase, telemetry: t };
+  }, [phase]);
+
+  const transition = (target: Phase) => {
+    const t = telemetryRef.current;
+    const now = Date.now();
+    t[phase].end = now;
+    if (!t[target].start) t[target].start = now;
+    setPhase(target);
+  };
+
+  const next = () => {
+    const nextPhase = journeyMap[phase].next;
+    if (nextPhase) transition(nextPhase);
+  };
+  const prev = () => {
+    const prevPhase = journeyMap[phase].prev;
+    if (prevPhase) transition(prevPhase);
+  };
+  const skip = (p: Phase) => {
+    if (phases.includes(p)) transition(p);
+  };
+  const reset = () => {
+    telemetryRef.current = Object.fromEntries(
+      phases.map((p) => [p, { start: 0, errors: [] }]),
+    ) as Record<Phase, Telemetry>;
+    setPhase(phases[0]);
+  };
+
+  return (
+    <JourneyContext.Provider
+      value={{ phase, telemetry: telemetryRef.current, next, prev, skip, reset }}
+    >
+      {children}
+    </JourneyContext.Provider>
+  );
+}

--- a/apps/web/lib/journey/guard.tsx
+++ b/apps/web/lib/journey/guard.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { journeyMap, phases, type Phase } from './map';
+import { useJourneyActions } from './hooks';
+
+export function PhaseGuard({
+  phase,
+  children,
+}: {
+  phase: Phase;
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const { skip } = useJourneyActions();
+
+  useEffect(() => {
+    if (!journeyMap[phase]) {
+      router.replace(`/journey/${phases[0]}`);
+      return;
+    }
+    skip(phase);
+  }, [phase, skip, router]);
+
+  return <>{children}</>;
+}

--- a/apps/web/lib/journey/hooks.ts
+++ b/apps/web/lib/journey/hooks.ts
@@ -1,0 +1,18 @@
+'use client';
+import { useContext } from 'react';
+import { JourneyContext } from './context';
+import type { Phase } from './map';
+
+export function usePhase(): Phase {
+  const ctx = useContext(JourneyContext);
+  if (!ctx) throw new Error('usePhase must be used within JourneyProvider');
+  return ctx.phase;
+}
+
+export function useJourneyActions() {
+  const ctx = useContext(JourneyContext);
+  if (!ctx)
+    throw new Error('useJourneyActions must be used within JourneyProvider');
+  const { next, prev, skip, reset } = ctx;
+  return { next, prev, skip, reset };
+}

--- a/apps/web/lib/journey/map.ts
+++ b/apps/web/lib/journey/map.ts
@@ -1,0 +1,60 @@
+export type Phase =
+  | 'Investigation'
+  | 'Detection'
+  | 'Analysis'
+  | 'Dimensioning'
+  | 'Recommendation'
+  | 'LeadMgmt';
+
+interface PhaseConfig {
+  next?: Phase;
+  prev?: Phase;
+  cards: string[];
+  viewers: string[];
+}
+
+export const journeyMap: Record<Phase, PhaseConfig> = {
+  Investigation: {
+    next: 'Detection',
+    cards: ['Intent', 'LeadValidation', 'LeadEnrichment'],
+    viewers: [],
+  },
+  Detection: {
+    prev: 'Investigation',
+    next: 'Analysis',
+    cards: ['Detection'],
+    viewers: [],
+  },
+  Analysis: {
+    prev: 'Detection',
+    next: 'Dimensioning',
+    cards: ['Analysis'],
+    viewers: [],
+  },
+  Dimensioning: {
+    prev: 'Analysis',
+    next: 'Recommendation',
+    cards: ['Dimensioning'],
+    viewers: [],
+  },
+  Recommendation: {
+    prev: 'Dimensioning',
+    next: 'LeadMgmt',
+    cards: ['Recommendation'],
+    viewers: [],
+  },
+  LeadMgmt: {
+    prev: 'Recommendation',
+    cards: ['LeadMgmt'],
+    viewers: [],
+  },
+};
+
+export const phases: Phase[] = [
+  'Investigation',
+  'Detection',
+  'Analysis',
+  'Dimensioning',
+  'Recommendation',
+  'LeadMgmt',
+];

--- a/tests/e2e/journey.test.ts
+++ b/tests/e2e/journey.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+const phases = [
+  'Investigation',
+  'Detection',
+  'Analysis',
+  'Dimensioning',
+  'Recommendation',
+  'LeadMgmt',
+];
+
+test('journey happy flow', async ({ page }) => {
+  await page.goto('/journey/Investigation');
+  for (const name of phases) {
+    await expect(page.getByRole('heading', { name })).toBeVisible();
+    if (name !== 'LeadMgmt') {
+      await page.click('#next');
+    }
+  }
+  const telemetry = await page.evaluate(() => (window as any).__journey.telemetry);
+  for (const name of phases) {
+    expect(telemetry[name].start).toBeTruthy();
+  }
+});
+
+test('journey deviation flow', async ({ page }) => {
+  await page.goto('/journey/Investigation');
+  await page.click('#skip');
+  await expect(page.getByRole('heading', { name: 'Recommendation' })).toBeVisible();
+  await page.click('#prev');
+  await expect(page.getByRole('heading', { name: 'Dimensioning' })).toBeVisible();
+  await page.click('#reset');
+  await expect(page.getByRole('heading', { name: 'Investigation' })).toBeVisible();
+  const telemetry = await page.evaluate(() => (window as any).__journey.telemetry);
+  expect(telemetry['Recommendation'].start).toBeTruthy();
+  expect(telemetry['Dimensioning'].start).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- define journey phase map and context for Investigation→LeadMgmt flow
- add hooks and guards to navigate phases with telemetry tracking
- wire basic journey pages and Playwright tests for phase navigation

## Testing
- `pnpm lint`
- `pnpm test tests/e2e/journey.test.ts` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4928e33c8332b15165197dd9ec91