### PR TITLE
feat: add risk score card component

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "fast-deep-equal": "^3.1.3",
     "framer-motion": "^11.3.19",
     "geist": "^1.3.1",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^0.446.0",
     "nanoid": "^5.0.8",
     "next": "15.3.0-canary.31",

--- a/packages/ui-cards/RiskScoreCard.test.ts
+++ b/packages/ui-cards/RiskScoreCard.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getRiskBucket } from './RiskScoreCard';
+
+describe('getRiskBucket', () => {
+  it('returns low for scores below 34', () => {
+    expect(getRiskBucket(0).bucket).toBe('low');
+    expect(getRiskBucket(33).bucket).toBe('low');
+  });
+
+  it('returns medium for scores between 34 and 66', () => {
+    expect(getRiskBucket(34).bucket).toBe('medium');
+    expect(getRiskBucket(66).bucket).toBe('medium');
+  });
+
+  it('returns high for scores 67 and above', () => {
+    expect(getRiskBucket(67).bucket).toBe('high');
+    expect(getRiskBucket(100).bucket).toBe('high');
+  });
+});

--- a/packages/ui-cards/RiskScoreCard.tsx
+++ b/packages/ui-cards/RiskScoreCard.tsx
@@ -1,0 +1,113 @@
+import React, { useRef } from 'react';
+import { z } from 'zod';
+
+// Schema validation for Risk Score data
+export const riskScoreSchema = z.object({
+  score: z.number().min(0).max(100),
+  drivers: z.array(z.object({ label: z.string(), value: z.number() })),
+});
+
+export type RiskScoreData = z.infer<typeof riskScoreSchema>;
+
+export type RiskBucket = 'low' | 'medium' | 'high';
+
+// Determine bucket and color based on score
+export function getRiskBucket(score: number): { bucket: RiskBucket; color: string } {
+  if (score < 34) return { bucket: 'low', color: '#16a34a' }; // green
+  if (score < 67) return { bucket: 'medium', color: '#facc15' }; // yellow
+  return { bucket: 'high', color: '#dc2626' }; // red
+}
+
+export const RiskScoreCard: React.FC<RiskScoreData> = (props) => {
+  const data = riskScoreSchema.parse(props);
+  const { bucket, color } = getRiskBucket(data.score);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Export card as PNG using dynamic import to avoid bundling issues
+  const exportAsPNG = async () => {
+    if (!ref.current) return;
+    const { toPng } = await import('html-to-image');
+    const dataUrl = await toPng(ref.current);
+    const link = document.createElement('a');
+    link.download = 'risk-score.png';
+    link.href = dataUrl;
+    link.click();
+  };
+
+  // Export card data as JSON
+  const exportAsJSON = () => {
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.download = 'risk-score.json';
+    link.href = url;
+    link.click();
+  };
+
+  const radius = 60;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (data.score / 100) * circumference;
+
+  return (
+    <div ref={ref} className="p-4 border rounded w-64">
+      <div className="relative w-32 h-32 mx-auto">
+        <svg width={160} height={160}>
+          <circle
+            cx="80"
+            cy="80"
+            r={radius}
+            stroke="#e5e7eb"
+            strokeWidth="10"
+            fill="none"
+          />
+          <circle
+            cx="80"
+            cy="80"
+            r={radius}
+            stroke={color}
+            strokeWidth="10"
+            fill="none"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            transform="rotate(-90 80 80)"
+          />
+          <text x="80" y="90" textAnchor="middle" fontSize="24">
+            {data.score}
+          </text>
+        </svg>
+      </div>
+      <div className="text-center mt-2">
+        <span className="font-bold" style={{ color }}>
+          {bucket.toUpperCase()}
+        </span>
+      </div>
+      <table className="w-full mt-4 text-sm">
+        <thead>
+          <tr>
+            <th className="text-left">Driver</th>
+            <th className="text-right">Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.drivers.map((d) => (
+            <tr key={d.label}>
+              <td>{d.label}</td>
+              <td className="text-right">{d.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex gap-2 mt-4">
+        <button type="button" onClick={exportAsPNG} className="px-2 py-1 border rounded">
+          PNG
+        </button>
+        <button type="button" onClick={exportAsJSON} className="px-2 py-1 border rounded">
+          JSON
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default RiskScoreCard;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       geist:
         specifier: ^1.3.1
         version: 1.3.1(next@15.3.0-canary.31(@opentelemetry/api@1.9.0)(@playwright/test@1.51.0)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021))
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       lucide-react:
         specifier: ^0.446.0
         version: 0.446.0(react@19.0.0-rc-45804af1-20241021)
@@ -3636,6 +3639,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -8674,6 +8680,8 @@ snapshots:
   highlightjs-vue@1.0.0: {}
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   html-url-attributes@3.0.1: {}
 


### PR DESCRIPTION
## Summary
- add RiskScoreCard component with gauge, driver table and bucket-based colors
- support PNG and JSON export
- test risk bucket classification

## Testing
- `npx vitest packages/ui-cards/RiskScoreCard.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ba4ff639a083328be563c9fab82d46