### PR TITLE
feat: add compliance card component

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "fast-deep-equal": "^3.1.3",
     "framer-motion": "^11.3.19",
     "geist": "^1.3.1",
+    "html2canvas": "^1.4.1",
     "lucide-react": "^0.446.0",
     "nanoid": "^5.0.8",
     "next": "15.3.0-canary.31",

--- a/packages/ui-cards/ComplianceCard.test.ts
+++ b/packages/ui-cards/ComplianceCard.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { filterIssuesBySeverity, type Issue } from './ComplianceCard';
+
+describe('filterIssuesBySeverity', () => {
+  const issues: Issue[] = [
+    { id: '1', description: 'Issue 1', severity: 'low' },
+    { id: '2', description: 'Issue 2', severity: 'medium' },
+    { id: '3', description: 'Issue 3', severity: 'high' },
+    { id: '4', description: 'Issue 4', severity: 'high' },
+  ];
+
+  it('returns all issues when severity is all', () => {
+    expect(filterIssuesBySeverity(issues, 'all')).toHaveLength(4);
+  });
+
+  it('filters issues by given severity', () => {
+    expect(filterIssuesBySeverity(issues, 'high')).toHaveLength(2);
+    expect(filterIssuesBySeverity(issues, 'medium')).toHaveLength(1);
+    expect(filterIssuesBySeverity(issues, 'low')).toHaveLength(1);
+  });
+});

--- a/packages/ui-cards/ComplianceCard.tsx
+++ b/packages/ui-cards/ComplianceCard.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+interface BadgeProps {
+  children: React.ReactNode;
+  variant?: 'secondary' | 'default' | 'destructive';
+  className?: string;
+}
+
+function Badge({ children, variant = 'default', className = '' }: BadgeProps) {
+  const base =
+    'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold';
+  const variants: Record<string, string> = {
+    default: 'bg-primary text-primary-foreground',
+    secondary: 'bg-secondary text-secondary-foreground',
+    destructive: 'bg-destructive text-destructive-foreground',
+  };
+  return (
+    <span className={`${base} ${variants[variant]} ${className}`.trim()}>{
+      children
+    }</span>
+  );
+}
+
+type Severity = 'low' | 'medium' | 'high';
+
+export interface Issue {
+  id: string;
+  description: string;
+  severity: Severity;
+  resolved?: boolean;
+}
+
+export interface ComplianceCardProps {
+  status: 'ok' | 'warn' | 'fail';
+  issues: Issue[];
+  reg_refs: string[];
+}
+
+export function filterIssuesBySeverity(
+  issues: Issue[],
+  severity: Severity | 'all',
+): Issue[] {
+  return severity === 'all'
+    ? issues
+    : issues.filter((issue) => issue.severity === severity);
+}
+
+const severityVariant = (
+  severity: Severity,
+): 'secondary' | 'default' | 'destructive' => {
+  switch (severity) {
+    case 'high':
+      return 'destructive';
+    case 'medium':
+      return 'default';
+    default:
+      return 'secondary';
+  }
+};
+
+const ComplianceCard: React.FC<ComplianceCardProps> = ({
+  status,
+  issues,
+  reg_refs,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState<Severity | 'all'>('all');
+  const [localIssues, setLocalIssues] = useState<Issue[]>(issues);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handleResolve = (id: string) => {
+    setLocalIssues((prev) =>
+      prev.map((issue) =>
+        issue.id === id ? { ...issue, resolved: true } : issue,
+      ),
+    );
+  };
+
+  const exportJSON = () => {
+    const data = JSON.stringify(
+      { status, issues: localIssues, reg_refs },
+      null,
+      2,
+    );
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'compliance-card.json';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportPNG = async () => {
+    if (!cardRef.current) return;
+    const html2canvas = (await import('html2canvas')).default;
+    const canvas = await html2canvas(cardRef.current);
+    const link = document.createElement('a');
+    link.href = canvas.toDataURL('image/png');
+    link.download = 'compliance-card.png';
+    link.click();
+  };
+
+  const filtered = filterIssuesBySeverity(localIssues, filter);
+
+  const severityCounts = {
+    low: issues.filter((i) => i.severity === 'low').length,
+    medium: issues.filter((i) => i.severity === 'medium').length,
+    high: issues.filter((i) => i.severity === 'high').length,
+  };
+
+  return (
+    <div
+      ref={cardRef}
+      className="rounded-lg border p-4"
+      aria-live="polite"
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Compliance Status: {status}</h2>
+        <button
+          type="button"
+          aria-expanded={open}
+          aria-controls="compliance-checklist"
+          onClick={() => setOpen((o) => !o)}
+          className="text-sm underline"
+        >
+          {open ? 'Hide checklist' : 'Open checklist'}
+        </button>
+      </div>
+      <div className="mt-2 flex gap-2">
+        <Badge variant="secondary">Low {severityCounts.low}</Badge>
+        <Badge>Medium {severityCounts.medium}</Badge>
+        <Badge variant="destructive">High {severityCounts.high}</Badge>
+      </div>
+      {open && (
+        <div id="compliance-checklist" className="mt-4">
+          <label htmlFor="severity-filter" className="sr-only">
+            Filter by severity
+          </label>
+          <select
+            id="severity-filter"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value as Severity | 'all')}
+            className="rounded border p-1"
+          >
+            <option value="all">All</option>
+            <option value="low">Low</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+          </select>
+          <ul className="mt-2 space-y-2">
+            {filtered.map((issue) => (
+              <li
+                key={issue.id}
+                className="flex items-center justify-between"
+              >
+                <span
+                  className={issue.resolved ? 'line-through' : ''}
+                >
+                  {issue.description}
+                </span>
+                <Badge
+                  className="ml-2"
+                  variant={severityVariant(issue.severity)}
+                >
+                  {issue.severity}
+                </Badge>
+                <button
+                  type="button"
+                  onClick={() => handleResolve(issue.id)}
+                  className="ml-2 text-xs underline"
+                >
+                  Mark as resolved
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {reg_refs.length > 0 && (
+        <div className="mt-4">
+          <h3 className="font-medium">Regulatory References</h3>
+          <ul className="list-inside list-disc">
+            {reg_refs.map((ref) => (
+              <li key={ref}>
+                <a
+                  href={ref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  {ref}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <div className="mt-4 flex gap-2">
+        <button
+          type="button"
+          onClick={exportJSON}
+          className="text-sm underline"
+        >
+          Export JSON
+        </button>
+        <button
+          type="button"
+          onClick={exportPNG}
+          className="text-sm underline"
+        >
+          Export PNG
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ComplianceCard;
+export type { Severity };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       geist:
         specifier: ^1.3.1
         version: 1.3.1(next@15.3.0-canary.31(@opentelemetry/api@1.9.0)(@playwright/test@1.51.0)(react-dom@19.0.0-rc-45804af1-20241021(react@19.0.0-rc-45804af1-20241021))(react@19.0.0-rc-45804af1-20241021))
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       lucide-react:
         specifier: ^0.446.0
         version: 0.446.0(react@19.0.0-rc-45804af1-20241021)
@@ -2584,6 +2587,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   bcrypt-ts@5.0.3:
     resolution: {integrity: sha512-2FcgD12xPbwCoe5i9/HK0jJ1xA1m+QfC1e6htG9Bl/hNOnLyaFmQSlqLKcfe3QdnoMPKpKEGFCbESBTg+SJNOw==}
     engines: {node: '>=18'}
@@ -2769,6 +2776,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -3642,6 +3652,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5042,6 +5056,9 @@ packages:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
 
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -5235,6 +5252,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -7421,6 +7441,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-arraybuffer@1.0.2: {}
+
   bcrypt-ts@5.0.3: {}
 
   binary-extensions@2.3.0: {}
@@ -7605,6 +7627,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
 
   cssesc@3.0.0: {}
 
@@ -8678,6 +8704,11 @@ snapshots:
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
+
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
 
   iconv-lite@0.6.3:
     dependencies:
@@ -10524,6 +10555,10 @@ snapshots:
       glob: 10.4.5
       minimatch: 9.0.5
 
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+
   text-table@0.2.0: {}
 
   thenify-all@1.6.0:
@@ -10728,6 +10763,10 @@ snapshots:
       react: 19.0.0-rc-45804af1-20241021
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@11.1.0: {}
 


### PR DESCRIPTION
## Summary
- add ComplianceCard component with severity filtering, export options, and accessible checklist
- add vitest tests for filtering by severity
- include html2canvas dependency for PNG export

## Testing
- `pnpm lint` *(fails: Provide an explicit type prop for the button element. Avoid using the index of an array as key property. The assignment should not be in an expression.)*
- `pnpm exec vitest run packages/ui-cards/ComplianceCard.test.ts`
- `pnpm test` *(fails: Serving HTML report at http://localhost:9323. Press Ctrl+C to quit.)*

------
https://chatgpt.com/codex/tasks/task_e_68ba506899548332b9eca202d8d5f574