### PR TITLE
feat(ui): add FinancingCard with offer comparison

### DIFF
--- a/packages/ui-cards/FinancingCard.test.tsx
+++ b/packages/ui-cards/FinancingCard.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FinancingCard, {
+  sortOffersByTotalCost,
+  type FinancingOffer,
+} from './FinancingCard';
+
+describe('sortOffersByTotalCost', () => {
+  it('orders offers by total cost ascending', () => {
+    const offers: FinancingOffer[] = [
+      { provider: 'A', rate: 2, term: 12, monthly: 100 }, // total 1200
+      { provider: 'B', rate: 3, term: 12, monthly: 90 }, // total 1080
+      { provider: 'C', rate: 1, term: 12, monthly: 110 }, // total 1320
+    ];
+    const sorted = sortOffersByTotalCost(offers);
+    expect(sorted.map((o) => o.provider)).toEqual(['B', 'A', 'C']);
+  });
+});
+
+describe('FinancingCard', () => {
+  it('highlights the best option', () => {
+    const offers: FinancingOffer[] = [
+      { provider: 'A', rate: 2, term: 12, monthly: 100 },
+      { provider: 'B', rate: 3, term: 12, monthly: 90 },
+      { provider: 'C', rate: 1, term: 12, monthly: 110 },
+    ];
+    render(<FinancingCard offers={offers} />);
+    const bestRow = screen.getByLabelText('best option');
+    expect(bestRow).toBeTruthy();
+    expect(bestRow.textContent).toContain('B');
+  });
+});

--- a/packages/ui-cards/FinancingCard.tsx
+++ b/packages/ui-cards/FinancingCard.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo } from 'react';
+import { z } from 'zod';
+import Papa from 'papaparse';
+
+// Schema for a financing offer
+export const financingOfferSchema = z.object({
+  provider: z.string(),
+  rate: z.number(),
+  term: z.number(), // in months
+  monthly: z.number(), // monthly payment
+});
+
+export type FinancingOffer = z.infer<typeof financingOfferSchema>;
+
+export const financingCardSchema = z.object({
+  offers: z.array(financingOfferSchema),
+});
+
+export type FinancingCardProps = z.infer<typeof financingCardSchema>;
+
+// Helper to calculate total cost
+export function getTotalCost(offer: FinancingOffer): number {
+  return offer.monthly * offer.term;
+}
+
+// Sort offers by total cost ascending
+export function sortOffersByTotalCost(
+  offers: FinancingOffer[],
+): FinancingOffer[] {
+  return offers.slice().sort((a, b) => getTotalCost(a) - getTotalCost(b));
+}
+
+export const FinancingCard: React.FC<FinancingCardProps> = (props) => {
+  const { offers } = financingCardSchema.parse(props);
+
+  // Sorted offers memoized for performance
+  const sorted = useMemo(() => sortOffersByTotalCost(offers), [offers]);
+  const best = sorted[0];
+
+  const exportAsCSV = () => {
+    const rows = sorted.map((o) => ({ ...o, total: getTotalCost(o) }));
+    const csv = Papa.unparse(rows);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.download = 'financing-options.csv';
+    link.href = url;
+    link.click();
+  };
+
+  const exportAsJSON = () => {
+    const json = JSON.stringify(
+      sorted.map((o) => ({ ...o, total: getTotalCost(o) })),
+      null,
+      2,
+    );
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.download = 'financing-options.json';
+    link.href = url;
+    link.click();
+  };
+
+  return (
+    <div className="p-4 border rounded w-full max-w-md">
+      <table className="w-full text-sm" aria-label="financing offers">
+        <thead>
+          <tr>
+            <th scope="col" className="text-left">
+              Provider
+            </th>
+            <th scope="col" className="text-right">
+              Rate (%)
+            </th>
+            <th scope="col" className="text-right">
+              Term (m)
+            </th>
+            <th scope="col" className="text-right">
+              Monthly
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((o) => (
+            <tr
+              key={o.provider}
+              className={o === best ? 'bg-yellow-100 font-bold' : ''}
+              aria-label={o === best ? 'best option' : undefined}
+            >
+              <td>{o.provider}</td>
+              <td className="text-right">{o.rate.toFixed(2)}</td>
+              <td className="text-right">{o.term}</td>
+              <td className="text-right">{o.monthly.toFixed(2)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex gap-2 mt-4">
+        <button
+          type="button"
+          onClick={exportAsCSV}
+          className="px-2 py-1 border rounded"
+          aria-label="export csv"
+        >
+          CSV
+        </button>
+        <button
+          type="button"
+          onClick={exportAsJSON}
+          className="px-2 py-1 border rounded"
+          aria-label="export json"
+        >
+          JSON
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default FinancingCard;


### PR DESCRIPTION
## Summary
- add FinancingCard component to list financing offers and highlight the most affordable option
- enable CSV and JSON export of sorted offers
- test offer sorting and best option highlighting

## Testing
- `npx vitest run packages/ui-cards/FinancingCard.test.tsx --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68ba51e7e1608332a576a0bb3d22df8f