### PR TITLE
feat(ui-cards): add ArchiveCard component

### DIFF
--- a/packages/ui-cards/ArchiveCard.test.ts
+++ b/packages/ui-cards/ArchiveCard.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { calculateTTL } from './ArchiveCard';
+
+describe('calculateTTL', () => {
+  it('returns remaining days until expiration', () => {
+    const ttl = calculateTTL('2024-01-01T00:00:00Z', 10, new Date('2024-01-01T00:00:00Z'));
+    expect(ttl).toBe(10);
+  });
+
+  it('returns 0 for expired archives', () => {
+    const ttl = calculateTTL('2024-01-01T00:00:00Z', 10, new Date('2024-01-15T00:00:00Z'));
+    expect(ttl).toBe(0);
+  });
+});

--- a/packages/ui-cards/ArchiveCard.tsx
+++ b/packages/ui-cards/ArchiveCard.tsx
@@ -1,0 +1,95 @@
+import React, { useRef } from 'react';
+import { z } from 'zod';
+
+// Schema validation for archive receipt data
+export const archiveReceiptSchema = z.object({
+  archived_at: z.string(),
+  ttl_policy: z.number(), // in days
+  checksum: z.string(),
+});
+
+export type ArchiveReceiptData = z.infer<typeof archiveReceiptSchema>;
+
+export interface ArchiveCardProps extends ArchiveReceiptData {
+  onRestore?: () => void;
+}
+
+// Calculate remaining TTL in days
+export function calculateTTL(
+  archivedAt: string,
+  ttlDays: number,
+  now: Date = new Date(),
+): number {
+  const archivedDate = new Date(archivedAt);
+  const expiresAt = new Date(archivedDate.getTime() + ttlDays * 24 * 60 * 60 * 1000);
+  const diff = expiresAt.getTime() - now.getTime();
+  return Math.max(0, Math.ceil(diff / (24 * 60 * 60 * 1000)));
+}
+
+export const ArchiveCard: React.FC<ArchiveCardProps> = (props) => {
+  const data = archiveReceiptSchema.parse(props);
+  const ttl = calculateTTL(data.archived_at, data.ttl_policy);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const exportAsPNG = async () => {
+    if (!ref.current) return;
+    const { toPng } = await import('html-to-image');
+    const dataUrl = await toPng(ref.current);
+    const link = document.createElement('a');
+    link.download = 'archive-card.png';
+    link.href = dataUrl;
+    link.click();
+  };
+
+  const exportAsJSON = () => {
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.download = 'archive-card.json';
+    link.href = url;
+    link.click();
+  };
+
+  const copyChecksum = async () => {
+    await navigator.clipboard.writeText(data.checksum);
+  };
+
+  return (
+    <div ref={ref} className="p-4 border rounded w-64">
+      <h3 className="font-bold mb-2">Recibo de Arquivamento</h3>
+      <p>
+        <span className="font-semibold">Arquivado em:</span>{' '}
+        {new Date(data.archived_at).toLocaleString()}
+      </p>
+      <p>
+        <span className="font-semibold">TTL:</span> {ttl} dias
+      </p>
+      <div className="flex items-center gap-2 mt-2">
+        <span className="truncate">{data.checksum}</span>
+        <button type="button" onClick={copyChecksum} className="px-2 py-1 border rounded">
+          Copiar
+        </button>
+      </div>
+      <div className="flex gap-2 mt-4">
+        {props.onRestore && (
+          <button
+            type="button"
+            onClick={props.onRestore}
+            className="px-2 py-1 border rounded"
+          >
+            Restaurar
+          </button>
+        )}
+        <button type="button" onClick={exportAsPNG} className="px-2 py-1 border rounded">
+          PNG
+        </button>
+        <button type="button" onClick={exportAsJSON} className="px-2 py-1 border rounded">
+          JSON
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ArchiveCard;


### PR DESCRIPTION
## Summary
- add ArchiveCard component to show archive receipt with TTL display and checksum copy
- include JSON/PNG export and optional restore handler
- test TTL calculation helper

## Testing
- `pnpm exec biome lint packages/ui-cards/ArchiveCard.tsx packages/ui-cards/ArchiveCard.test.ts`
- `pnpm exec vitest packages/ui-cards/ArchiveCard.test.ts packages/ui-cards/RiskScoreCard.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ba520e1c608332a107c273421bd219