### PR TITLE
feat: add financing simulator

### DIFF
--- a/lib/finance/financingSimulator.test.ts
+++ b/lib/finance/financingSimulator.test.ts
@@ -9,7 +9,7 @@ describe('simulateFinancing', () => {
       termMonths: 24,
     });
     // Expected value calculated externally ~443.21
-    expect(monthlyPayment).toBeCloseTo(443.21, 2);
+    expect(monthlyPayment).toBe(443.21);
   });
 
   it('calculates payback period when savings exceed payment', () => {
@@ -21,6 +21,17 @@ describe('simulateFinancing', () => {
     });
     // payment around 428.04 => payback months approx ceil(5000 / (600-428.04)) = 30
     expect(result.paybackPeriodMonths).toBe(30);
+    expect(Number.isInteger(result.paybackPeriodMonths)).toBe(true);
+  });
+
+  it('rounds monthly payment to two decimals', () => {
+    const { monthlyPayment } = simulateFinancing({
+      principal: 10000,
+      annualRate: 0.05,
+      termMonths: 24,
+    });
+    expect(monthlyPayment).toBe(438.71);
+    expect(Number.isInteger(monthlyPayment * 100)).toBe(true);
   });
 
   it('throws on invalid input', () => {

--- a/lib/finance/financingSimulator.ts
+++ b/lib/finance/financingSimulator.ts
@@ -20,6 +20,11 @@ export interface FinancingResult {
   paybackPeriodMonths?: number;
 }
 
+// Round a number to two decimal places (cents)
+function roundCents(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
 /**
  * Simulates a simple financing scenario.
  *
@@ -27,7 +32,9 @@ export interface FinancingResult {
  *
  * @param params Financing parameters
  */
-export function simulateFinancing(params: FinancingParameters): FinancingResult {
+export function simulateFinancing(
+  params: FinancingParameters,
+): FinancingResult {
   const { principal, annualRate, termMonths, monthlySavings } = params;
   if (principal <= 0) throw new Error('principal must be positive');
   if (annualRate < 0) throw new Error('annualRate must be non-negative');
@@ -36,17 +43,21 @@ export function simulateFinancing(params: FinancingParameters): FinancingResult 
   const monthlyRate = annualRate / 12;
 
   // Handle zero interest specially to avoid division by zero
-  const monthlyPayment =
+  const rawMonthlyPayment =
     monthlyRate === 0
       ? principal / termMonths
-      : (principal * monthlyRate) / (1 - Math.pow(1 + monthlyRate, -termMonths));
+      : (principal * monthlyRate) /
+        (1 - Math.pow(1 + monthlyRate, -termMonths));
+  const monthlyPayment = roundCents(rawMonthlyPayment);
 
   const result: FinancingResult = {
     monthlyPayment,
   };
 
   if (monthlySavings !== undefined && monthlySavings > monthlyPayment) {
-    const paybackMonths = Math.ceil(principal / (monthlySavings - monthlyPayment));
+    const paybackMonths = Math.ceil(
+      principal / (monthlySavings - rawMonthlyPayment),
+    );
     result.paybackPeriodMonths = paybackMonths;
   }
 

--- a/packages/ui-cards/FinancingCard.tsx
+++ b/packages/ui-cards/FinancingCard.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+export interface FinancingCardProps {
+  principal: number;
+  annualRate: number;
+  termMonths: number;
+  monthlyPayment: number;
+  paybackPeriodMonths?: number;
+}
+
+function formatCurrency(value: number): string {
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+export const FinancingCard: React.FC<FinancingCardProps> = ({
+  principal,
+  annualRate,
+  termMonths,
+  monthlyPayment,
+  paybackPeriodMonths,
+}) => {
+  return (
+    <div className="p-4 border rounded w-64 text-sm">
+      <div className="mb-2">
+        <strong>Principal:</strong> ${'{'}formatCurrency(principal){'}'}
+      </div>
+      <div className="mb-2">
+        <strong>Rate:</strong> {(annualRate * 100).toFixed(2)}%
+      </div>
+      <div className="mb-2">
+        <strong>Term:</strong> {termMonths} months
+      </div>
+      <div className="mb-2">
+        <strong>Monthly Payment:</strong> ${'{'}formatCurrency(monthlyPayment)
+        {'}'}
+      </div>
+      {paybackPeriodMonths !== undefined && (
+        <div>
+          <strong>Payback:</strong> {paybackPeriodMonths} months
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FinancingCard;

--- a/packages/ui-editors/FinancingSimulator.tsx
+++ b/packages/ui-editors/FinancingSimulator.tsx
@@ -1,0 +1,169 @@
+import React, { useMemo, useState } from 'react';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import Papa from 'papaparse';
+import FinancingCard from '../ui-cards/FinancingCard';
+import { simulateFinancing } from '../../lib/finance/financingSimulator';
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function generateSchedule(
+  principal: number,
+  annualRate: number,
+  termMonths: number,
+) {
+  const { monthlyPayment } = simulateFinancing({
+    principal,
+    annualRate,
+    termMonths,
+  });
+  const monthlyRate = annualRate / 12;
+  let balance = principal;
+  const rows = [] as Array<{
+    month: number;
+    payment: number;
+    principal: number;
+    interest: number;
+    balance: number;
+  }>;
+  for (let month = 1; month <= termMonths; month++) {
+    const interest = round(balance * monthlyRate);
+    const principalPaid = round(monthlyPayment - interest);
+    balance = round(balance - principalPaid);
+    rows.push({
+      month,
+      payment: monthlyPayment,
+      principal: principalPaid,
+      interest,
+      balance: balance < 0 ? 0 : balance,
+    });
+  }
+  return rows;
+}
+
+export const FinancingSimulator: React.FC = () => {
+  const [principal, setPrincipal] = useState(10000);
+  const [annualRate, setAnnualRate] = useState(0.05);
+  const [termMonths, setTermMonths] = useState(24);
+  const [monthlySavings, setMonthlySavings] = useState(0);
+
+  const result = useMemo(
+    () =>
+      simulateFinancing({ principal, annualRate, termMonths, monthlySavings }),
+    [principal, annualRate, termMonths, monthlySavings],
+  );
+
+  const exportCSV = () => {
+    const schedule = generateSchedule(principal, annualRate, termMonths);
+    const csv = Papa.unparse(schedule);
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'financing-schedule.csv';
+    link.click();
+  };
+
+  const formulaPayment = 'M = P * r / (1 - (1+r)^-n)';
+  const formulaPayback = 'n = ceil(P / (S - M))';
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block mb-1">Principal</label>
+        <input
+          type="number"
+          className="border p-1 w-full"
+          value={principal}
+          onChange={(e) => setPrincipal(Number(e.target.value))}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">
+          Interest Rate: {(annualRate * 100).toFixed(2)}%
+        </label>
+        <input
+          type="range"
+          min={0}
+          max={0.2}
+          step={0.001}
+          value={annualRate}
+          onChange={(e) => setAnnualRate(Number(e.target.value))}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Term: {termMonths} months</label>
+        <input
+          type="range"
+          min={1}
+          max={360}
+          value={termMonths}
+          onChange={(e) => setTermMonths(Number(e.target.value))}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Monthly Savings</label>
+        <input
+          type="number"
+          className="border p-1 w-full"
+          value={monthlySavings}
+          onChange={(e) => setMonthlySavings(Number(e.target.value))}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold">Monthly Payment</span>
+          <Tooltip.Provider>
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <span className="underline cursor-help text-xs">formula</span>
+              </Tooltip.Trigger>
+              <Tooltip.Content className="bg-black text-white p-1 rounded text-xs">
+                {formulaPayment}
+              </Tooltip.Content>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+          <span>
+            ${'{'}result.monthlyPayment.toFixed(2){'}'}
+          </span>
+        </div>
+        {result.paybackPeriodMonths !== undefined && (
+          <div className="flex items-center gap-2">
+            <span className="font-semibold">Payback Period</span>
+            <Tooltip.Provider>
+              <Tooltip.Root>
+                <Tooltip.Trigger asChild>
+                  <span className="underline cursor-help text-xs">formula</span>
+                </Tooltip.Trigger>
+                <Tooltip.Content className="bg-black text-white p-1 rounded text-xs">
+                  {formulaPayback}
+                </Tooltip.Content>
+              </Tooltip.Root>
+            </Tooltip.Provider>
+            <span>{result.paybackPeriodMonths} months</span>
+          </div>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={exportCSV}
+        className="px-2 py-1 border rounded"
+      >
+        Export CSV
+      </button>
+
+      <FinancingCard
+        principal={principal}
+        annualRate={annualRate}
+        termMonths={termMonths}
+        monthlyPayment={result.monthlyPayment}
+        paybackPeriodMonths={result.paybackPeriodMonths}
+      />
+    </div>
+  );
+};
+
+export default FinancingSimulator;


### PR DESCRIPTION
## Summary
- add FinancingCard for displaying financing info
- implement FinancingSimulator editor with sliders, formula tooltips, CSV export and card integration
- round financing calculations to cents and add tests for rounding and units

## Testing
- `npx vitest run` *(fails: Cannot find package '@/tests/prompts/utils' ...)*
- `npx vitest run lib/finance/financingSimulator.test.ts`
- `npx biome format --write lib/finance/financingSimulator.ts lib/finance/financingSimulator.test.ts packages/ui-cards/FinancingCard.tsx packages/ui-editors/FinancingSimulator.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba528f82288332bacf681ad21a1ec1