### PR TITLE
feat: add version timeline component

### DIFF
--- a/app/test-canvas/page.tsx
+++ b/app/test-canvas/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/apps/web/components/canvas/Card';
+import {
+  VersionTimeline,
+  type Version,
+} from '@/apps/web/components/canvas/VersionTimeline';
+
+export default function Page() {
+  const [versions, setVersions] = useState<Version[]>([
+    {
+      id: 'v1',
+      timestamp: new Date().toISOString(),
+      author: 'tester',
+      note: 'v1',
+      data: { value: 1 },
+    },
+  ]);
+  const [current, setCurrent] = useState('v1');
+
+  const addVersion = () => {
+    const id = `v${versions.length + 1}`;
+    const v: Version = {
+      id,
+      timestamp: new Date().toISOString(),
+      author: 'tester',
+      note: id,
+      data: { value: versions.length + 1 },
+    };
+    setVersions([v, ...versions]);
+    setCurrent(id);
+  };
+
+  const handleRestore = (v: Version) => {
+    setCurrent(v.id);
+  };
+
+  const handleBranch = (v: Version) => {
+    const id = `${v.id}-b`;
+    const branch: Version = {
+      id,
+      timestamp: new Date().toISOString(),
+      author: 'tester',
+      note: id,
+      data: { ...v.data, branched: true },
+    };
+    setVersions([branch, ...versions]);
+    setCurrent(id);
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      <button id="create-version" onClick={addVersion}>
+        Create
+      </button>
+      <div data-testid="current-version">{current}</div>
+      <Card id="card1" title="Card">
+        <VersionTimeline
+          versions={versions}
+          current={current}
+          onRestore={handleRestore}
+          onBranch={handleBranch}
+        />
+      </Card>
+    </div>
+  );
+}
+

--- a/apps/web/components/canvas/VersionTimeline.tsx
+++ b/apps/web/components/canvas/VersionTimeline.tsx
@@ -1,35 +1,161 @@
-interface Version {
+'use client';
+
+import { useEffect, useState } from 'react';
+import equal from 'fast-deep-equal';
+import { trace } from '@opentelemetry/api';
+
+export interface Version {
   id: string;
-  label: string;
+  timestamp: string | number | Date;
+  author: string;
+  note?: string;
+  data: Record<string, unknown>;
 }
 
 interface VersionTimelineProps {
   versions: Version[];
-  onSelect?: (v: Version) => void;
+  current?: string;
+  onRestore?: (v: Version) => void;
   onBranch?: (v: Version) => void;
 }
 
-export function VersionTimeline({ versions, onSelect, onBranch }: VersionTimelineProps) {
+function diffObjects(
+  prev: Record<string, unknown>,
+  next: Record<string, unknown>,
+) {
+  const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
+  const changes: Array<{ key: string; before: unknown; after: unknown }> = [];
+  keys.forEach((k) => {
+    if (!equal(prev[k], next[k])) {
+      changes.push({ key: k, before: prev[k], after: next[k] });
+    }
+  });
+  return changes;
+}
+
+export function VersionTimeline({
+  versions,
+  current,
+  onRestore,
+  onBranch,
+}: VersionTimelineProps) {
+  const [index, setIndex] = useState(() =>
+    Math.max(0, versions.findIndex((v) => v.id === current)),
+  );
+
+  useEffect(() => {
+    const idx = versions.findIndex((v) => v.id === current);
+    if (idx !== -1) setIndex(idx);
+  }, [current, versions]);
+
+  const restore = (i: number) => {
+    const version = versions[i];
+    if (!version) return;
+    const span = trace.getTracer('card').startSpan('card.version.rollback');
+    try {
+      setIndex(i);
+      onRestore?.(version);
+    } finally {
+      span.end();
+    }
+  };
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        if (index + 1 < versions.length) restore(index + 1);
+      }
+      if (e.ctrlKey && e.key.toLowerCase() === 'y') {
+        e.preventDefault();
+        if (index - 1 >= 0) restore(index - 1);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [index, versions]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setIndex((i) => Math.min(i + 1, versions.length - 1));
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setIndex((i) => Math.max(i - 1, 0));
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      restore(index);
+    }
+  };
+
   return (
-    <ol className="p-2 space-y-1 text-sm">
-      {versions.map((v) => (
-        <li key={v.id} className="flex items-center gap-2">
-          <button
-            type="button"
-            className="underline"
-            onClick={() => onSelect?.(v)}
+    <ol
+      className="p-2 space-y-2 text-sm"
+      role="listbox"
+      tabIndex={0}
+      aria-activedescendant={versions[index]?.id}
+      onKeyDown={onKeyDown}
+    >
+      {versions.map((v, i) => {
+        const prev = versions[i + 1];
+        const delta = diffObjects(prev?.data ?? {}, v.data ?? {});
+        return (
+          <li
+            key={v.id}
+            id={v.id}
+            data-testid={`version-${i}`}
+            role="option"
+            aria-selected={i === index}
+            className={`border p-2 rounded ${
+              i === index ? 'bg-blue-50' : ''
+            }`}
           >
-            {v.label}
-          </button>
-          <button
-            type="button"
-            className="text-xs"
-            onClick={() => onBranch?.(v)}
-          >
-            branch
-          </button>
-        </li>
-      ))}
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="font-medium">{v.note ?? v.id}</div>
+                <div className="text-xs text-gray-500">
+                  {new Date(v.timestamp).toLocaleString()} – {v.author}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="underline"
+                  onClick={() => restore(i)}
+                >
+                  Rollback
+                </button>
+                <button
+                  type="button"
+                  className="underline"
+                  onClick={() => onBranch?.(v)}
+                >
+                  Branch
+                </button>
+              </div>
+            </div>
+            {delta.length > 0 && (
+              <div className="mt-1">
+                {delta.map((d) => (
+                  <div key={d.key} className="whitespace-pre-wrap">
+                    <span>{d.key}: </span>
+                    <span className="text-red-600 line-through">
+                      {JSON.stringify(d.before)}
+                    </span>
+                    <span> → </span>
+                    <span className="text-green-600">
+                      {JSON.stringify(d.after)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </li>
+        );
+      })}
     </ol>
   );
 }
+

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,14 +53,14 @@ export default defineConfig({
   projects: [
     {
       name: 'e2e',
-      testMatch: /e2e\/.*.test.ts/,
+      testMatch: /e2e\/.*\.(test|spec)\.ts/,
       use: {
         ...devices['Desktop Chrome'],
       },
     },
     {
       name: 'routes',
-      testMatch: /routes\/.*.test.ts/,
+      testMatch: /routes\/.*\.(test|spec)\.ts/,
       use: {
         ...devices['Desktop Chrome'],
       },

--- a/tests/e2e/canvas-version.spec.ts
+++ b/tests/e2e/canvas-version.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+// E2E for VersionTimeline component within test-canvas page
+
+/*
+Steps:
+1. Create a new version and see diff
+2. Rollback via Ctrl+Z and redo via Ctrl+Y
+3. Navigate via arrows and Enter
+4. Branch from an older version
+*/
+
+test('version timeline: create, rollback, branch', async ({ page }) => {
+  await page.goto('/test-canvas');
+
+  await page.click('#create-version');
+  await expect(page.getByTestId('version-0')).toContainText('v2');
+  await expect(page.getByTestId('version-0')).toContainText('→');
+  await expect(page.getByTestId('current-version')).toHaveText('v2');
+
+  await page.keyboard.press('Control+Z');
+  await expect(page.getByTestId('current-version')).toHaveText('v1');
+
+  await page.keyboard.press('Control+Y');
+  await expect(page.getByTestId('current-version')).toHaveText('v2');
+
+  await page.getByRole('listbox').focus();
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+  await expect(page.getByTestId('current-version')).toHaveText('v1');
+
+  await page.getByTestId('version-1').getByRole('button', { name: /branch/i }).click();
+  await expect(page.getByTestId('version-0')).toContainText('v1-b');
+  await expect(page.getByTestId('current-version')).toHaveText('v1-b');
+});
+


### PR DESCRIPTION
## Summary
- implement accessible VersionTimeline with rollback, branching and diff display
- add test page and E2E spec to exercise create/rollback/branch flows
- expand Playwright config to run `.spec.ts` tests

## Testing
- `pnpm test tests/e2e/canvas-version.spec.ts` *(fails: libgbm1, libxkbcommon0, libasound2t64 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4ede18e883328f97c46a1aaa3ebd