### PR TITLE
feat: add ChartKit component

### DIFF
--- a/packages/ui-charts/ChartKit.test.tsx
+++ b/packages/ui-charts/ChartKit.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ChartKit, { type ChartKitHandle } from './ChartKit';
+
+vi.mock('html-to-image', () => ({
+  toPng: vi.fn().mockResolvedValue('data:image/png;base64,abc'),
+}));
+
+describe('ChartKit', () => {
+  it('renders with accessible role', () => {
+    const { getByRole } = render(
+      <ChartKit type="histogram" data={[1, 2, 3]} ariaLabel="Histogram" />,
+    );
+    expect(getByRole('img', { name: 'Histogram' })).toBeTruthy();
+  });
+
+  it('exports PNG image', async () => {
+    const ref = React.createRef<ChartKitHandle>();
+    render(
+      <ChartKit
+        ref={ref}
+        type="histogram"
+        data={[1, 2, 3]}
+        ariaLabel="Histogram"
+      />,
+    );
+    const url = await ref.current?.exportToPNG();
+    expect(url).toContain('data:image/png');
+  });
+});

--- a/packages/ui-charts/ChartKit.tsx
+++ b/packages/ui-charts/ChartKit.tsx
@@ -1,0 +1,77 @@
+import React, { forwardRef, useImperativeHandle, useRef } from 'react';
+import RadarChart from './RadarChart';
+import WaterfallChart from './WaterfallChart';
+import HeatmapChart from './HeatmapChart';
+import LoadCurveChart from './LoadCurveChart';
+import HistogramChart from './HistogramChart';
+
+export type ChartType = 'radar' | 'waterfall' | 'heatmap' | 'load-curve' | 'histogram';
+
+export interface ChartKitProps {
+  type: ChartType;
+  data: unknown;
+  width?: number;
+  height?: number;
+  ariaLabel: string;
+}
+
+export interface ChartKitHandle {
+  exportToPNG: () => Promise<string | undefined>;
+}
+
+const ChartKit = forwardRef<ChartKitHandle, ChartKitProps>((props, ref) => {
+  const { type, data, width = 300, height = 300, ariaLabel } = props;
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const exportToPNG = async () => {
+    if (!containerRef.current) return undefined;
+    const { toPng } = await import('html-to-image');
+    return toPng(containerRef.current);
+  };
+
+  useImperativeHandle(ref, () => ({ exportToPNG }));
+
+  let chart: React.ReactNode = null;
+  switch (type) {
+    case 'radar':
+      chart = (
+        <RadarChart data={data as any} width={width} height={height} />
+      );
+      break;
+    case 'waterfall':
+      chart = (
+        <WaterfallChart data={data as any} width={width} height={height} />
+      );
+      break;
+    case 'heatmap':
+      chart = (
+        <HeatmapChart data={data as any} width={width} height={height} />
+      );
+      break;
+    case 'load-curve':
+      chart = (
+        <LoadCurveChart data={data as any} width={width} height={height} />
+      );
+      break;
+    case 'histogram':
+      chart = (
+        <HistogramChart data={data as any} width={width} height={height} />
+      );
+      break;
+    default:
+      chart = null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width, height }}
+      role="img"
+      aria-label={ariaLabel}
+    >
+      {chart}
+    </div>
+  );
+});
+
+export default React.memo(ChartKit);

--- a/packages/ui-charts/HeatmapChart.tsx
+++ b/packages/ui-charts/HeatmapChart.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export interface HeatmapChartProps {
+  data: number[][];
+  width: number;
+  height: number;
+}
+
+const HeatmapChart: React.FC<HeatmapChartProps> = ({ data, width, height }) => {
+  const rows = data.length;
+  const cols = data[0]?.length ?? 0;
+  const flat = data.flat();
+  const max = Math.max(...flat, 0);
+  const cellWidth = width / cols;
+  const cellHeight = height / rows;
+  return (
+    <svg width={width} height={height}>
+      {data.map((row, y) =>
+        row.map((value, x) => {
+          const intensity = max ? value / max : 0;
+          const color = `rgba(59,130,246,${intensity})`;
+          const key = `${x}-${y}-${value}`;
+          return (
+            <rect
+              key={key}
+              x={x * cellWidth}
+              y={y * cellHeight}
+              width={cellWidth}
+              height={cellHeight}
+              fill={color}
+            />
+          );
+        }),
+      )}
+    </svg>
+  );
+};
+
+export default React.memo(HeatmapChart);

--- a/packages/ui-charts/HistogramChart.tsx
+++ b/packages/ui-charts/HistogramChart.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+export function computeHistogram(
+  data: number[],
+  bins = Math.ceil(Math.sqrt(data.length))
+) {
+  const min = Math.min(...data);
+  const max = Math.max(...data);
+  const step = (max - min) / bins || 1;
+  const counts = new Array(bins).fill(0);
+  data.forEach((d) => {
+    const idx = Math.min(Math.floor((d - min) / step), bins - 1);
+    counts[idx]++;
+  });
+  return { counts, min, step };
+}
+
+export interface HistogramChartProps {
+  data: number[];
+  width: number;
+  height: number;
+  bins?: number;
+}
+
+const HistogramChart: React.FC<HistogramChartProps> = ({ data, width, height, bins }) => {
+  const { counts } = computeHistogram(data, bins);
+  const maxCount = Math.max(...counts, 0);
+  const barWidth = width / counts.length;
+  return (
+    <svg width={width} height={height}>
+      {counts.map((count, i) => {
+        const barHeight = maxCount ? (count / maxCount) * height : 0;
+        const key = `${i}-${count}`;
+        return (
+          <rect
+            key={key}
+            x={i * barWidth}
+            y={height - barHeight}
+            width={barWidth - 1}
+            height={barHeight}
+            fill="#3b82f6"
+          />
+        );
+      })}
+    </svg>
+  );
+};
+
+export default React.memo(HistogramChart);

--- a/packages/ui-charts/LoadCurveChart.tsx
+++ b/packages/ui-charts/LoadCurveChart.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export interface LoadCurvePoint {
+  x: number;
+  y: number;
+}
+
+export interface LoadCurveChartProps {
+  data: LoadCurvePoint[];
+  width: number;
+  height: number;
+}
+
+const LoadCurveChart: React.FC<LoadCurveChartProps> = ({ data, width, height }) => {
+  const xs = data.map((d) => d.x);
+  const ys = data.map((d) => d.y);
+  const minX = Math.min(...xs);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys, 0);
+  const path = data
+    .map((d, i) => {
+      const x = ((d.x - minX) / (maxX - minX || 1)) * width;
+      const y = height - (d.y / (maxY || 1)) * height;
+      return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+    })
+    .join(' ');
+  return (
+    <svg width={width} height={height}>
+      <path d={path} fill="none" stroke="#3b82f6" strokeWidth={2} />
+    </svg>
+  );
+};
+
+export default React.memo(LoadCurveChart);

--- a/packages/ui-charts/RadarChart.tsx
+++ b/packages/ui-charts/RadarChart.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export interface RadarChartProps {
+  data: { label: string; value: number }[];
+  width: number;
+  height: number;
+}
+
+const RadarChart: React.FC<RadarChartProps> = ({ data, width, height }) => {
+  const radius = Math.min(width, height) / 2;
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const angleStep = (Math.PI * 2) / data.length;
+  const points = data
+    .map((d, i) => {
+      const angle = i * angleStep - Math.PI / 2;
+      const r = d.value * radius;
+      return `${centerX + r * Math.cos(angle)},${centerY + r * Math.sin(angle)}`;
+    })
+    .join(' ');
+  return (
+    <svg width={width} height={height}>
+      <polygon points={points} fill="rgba(59,130,246,0.4)" stroke="#3b82f6" />
+    </svg>
+  );
+};
+
+export default React.memo(RadarChart);

--- a/packages/ui-charts/WaterfallChart.tsx
+++ b/packages/ui-charts/WaterfallChart.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export interface WaterfallChartProps {
+  data: { label: string; value: number }[];
+  width: number;
+  height: number;
+}
+
+const WaterfallChart: React.FC<WaterfallChartProps> = ({ data, width, height }) => {
+  const cumulative: number[] = [];
+  data.reduce((acc, d) => {
+    const next = acc + d.value;
+    cumulative.push(next);
+    return next;
+  }, 0);
+  const maxVal = Math.max(...cumulative, 0);
+  const barWidth = width / data.length;
+  return (
+    <svg width={width} height={height}>
+      {data.map((d, i) => {
+        const start = i === 0 ? 0 : cumulative[i - 1];
+        const end = cumulative[i];
+        const y = height - (Math.max(start, end) / maxVal) * height;
+        const barHeight = (Math.abs(end - start) / maxVal) * height;
+        const x = i * barWidth;
+        return (
+          <rect
+            key={d.label}
+            x={x}
+            y={y}
+            width={barWidth - 2}
+            height={barHeight}
+            fill={d.value >= 0 ? '#16a34a' : '#dc2626'}
+          />
+        );
+      })}
+    </svg>
+  );
+};
+
+export default React.memo(WaterfallChart);

--- a/packages/ui-charts/index.ts
+++ b/packages/ui-charts/index.ts
@@ -1,0 +1,7 @@
+export { default as ChartKit } from './ChartKit';
+export type { ChartKitProps, ChartKitHandle, ChartType } from './ChartKit';
+export { default as RadarChart } from './RadarChart';
+export { default as WaterfallChart } from './WaterfallChart';
+export { default as HeatmapChart } from './HeatmapChart';
+export { default as LoadCurveChart } from './LoadCurveChart';
+export { default as HistogramChart } from './HistogramChart';


### PR DESCRIPTION
## Summary
- add ChartKit wrapper with PNG export and a11y hooks
- implement radar, waterfall, heatmap, load curve, and histogram charts
- include basic test scaffold for ChartKit

## Testing
- `pnpm lint packages/ui-charts`
- `npx vitest packages/ui-charts/ChartKit.test.tsx` *(fails: document is not defined, other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ba52d4b358833280605817cc2596b2