### PR TITLE
feat: add financing picker component

### DIFF
--- a/apps/web/components/personas/owner/FinancingPicker.test.tsx
+++ b/apps/web/components/personas/owner/FinancingPicker.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { FinancingPicker } from './FinancingPicker';
+import type { FinancingOffer } from '@/packages/ui-cards/FinancingCard';
+
+describe('FinancingPicker', () => {
+  const offers: FinancingOffer[] = [
+    { provider: 'Bank A', rate: 3.5, term: 60, monthly: 200 },
+    { provider: 'Bank B', rate: 4.0, term: 48, monthly: 220 },
+  ];
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows offer details on request', async () => {
+    const user = userEvent.setup();
+    render(<FinancingPicker offers={offers} />);
+    await user.click(screen.getByRole('button', { name: 'details Bank A' }));
+    expect(
+      screen.getByRole('table', { name: 'financing offers' }),
+    ).toBeTruthy();
+  });
+
+  it('selects and saves an offer', async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+    render(<FinancingPicker offers={offers} onSave={onSave} />);
+    await user.click(screen.getByRole('button', { name: 'select Bank B' }));
+    await user.click(screen.getByRole('button', { name: 'save selection' }));
+    expect(onSave).toHaveBeenCalledWith(offers[1]);
+  });
+});

--- a/apps/web/components/personas/owner/FinancingPicker.tsx
+++ b/apps/web/components/personas/owner/FinancingPicker.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import FinancingCard, {
+  type FinancingOffer,
+} from '../../../../../packages/ui-cards/FinancingCard';
+
+interface FinancingPickerProps {
+  offers: FinancingOffer[];
+  onSave?: (offer: FinancingOffer) => void;
+}
+
+export function FinancingPicker({ offers, onSave }: FinancingPickerProps) {
+  const [selected, setSelected] = useState<FinancingOffer | null>(null);
+  const [detailsIndex, setDetailsIndex] = useState<number | null>(null);
+
+  const handleSave = () => {
+    if (selected) onSave?.(selected);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {offers.map((offer, idx) => (
+        <div key={offer.provider} className="border rounded p-2">
+          <div className="flex justify-between items-center">
+            <div>
+              <div className="font-semibold">{offer.provider}</div>
+              <div className="text-sm text-gray-600">
+                {offer.rate.toFixed(2)}% · {offer.term}m · $
+                {offer.monthly.toFixed(2)}
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                aria-label={`select ${offer.provider}`}
+                onClick={() => setSelected(offer)}
+                className="px-2 py-1 border rounded"
+              >
+                {selected?.provider === offer.provider ? 'Selected' : 'Select'}
+              </button>
+              <button
+                type="button"
+                aria-label={`details ${offer.provider}`}
+                onClick={() =>
+                  setDetailsIndex(detailsIndex === idx ? null : idx)
+                }
+                className="px-2 py-1 border rounded"
+              >
+                View details
+              </button>
+            </div>
+          </div>
+          {detailsIndex === idx && (
+            <div className="mt-2">
+              <FinancingCard offers={[offer]} />
+            </div>
+          )}
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={!selected}
+        className="px-3 py-2 border rounded self-start"
+        aria-label="save selection"
+      >
+        Save
+      </button>
+    </div>
+  );
+}
+
+export default FinancingPicker;


### PR DESCRIPTION
## Summary
- add FinancingPicker component to select from recommended financing offers
- show offer details via FinancingCard and allow saving chosen offer
- test offer detail display and selection handling

## Testing
- `pnpm exec vitest run apps/web/components/personas/owner/FinancingPicker.test.tsx --environment jsdom`
- `pnpm test` *(fails: 34 did not run)*

------
https://chatgpt.com/codex/tasks/task_e_68ba54961e5c83329ba06765268f2019