### PR TITLE
feat: add microinteraction scaffolding

### DIFF
--- a/lib/microinteractions.ts
+++ b/lib/microinteractions.ts
@@ -1,0 +1,112 @@
+import { randomUUID } from "node:crypto";
+
+export type LeadId = string;
+
+export interface ActionLog<T = unknown> {
+  id: string;
+  type: string;
+  payload: T;
+  leadId: LeadId;
+  timestamp: number;
+}
+
+export class ActionLogger {
+  private logs: ActionLog[] = [];
+  private seen = new Map<string, ActionLog>();
+
+  log<T>(type: string, payload: T, leadId: LeadId): ActionLog<T> {
+    const key = `${leadId}:${type}:${JSON.stringify(payload)}`;
+    const existing = this.seen.get(key);
+    if (existing) return existing as ActionLog<T>;
+
+    const entry: ActionLog<T> = {
+      id: randomUUID(),
+      type,
+      payload,
+      leadId,
+      timestamp: Date.now(),
+    };
+    this.logs.push(entry);
+    this.seen.set(key, entry);
+    return entry;
+  }
+
+  history(): ActionLog[] {
+    return [...this.logs];
+  }
+}
+
+export class ActionHistory {
+  private past: ActionLog[] = [];
+  private future: ActionLog[] = [];
+
+  commit(log: ActionLog) {
+    this.past.push(log);
+    this.future = [];
+  }
+
+  undo(): ActionLog | undefined {
+    const log = this.past.pop();
+    if (log) this.future.push(log);
+    return log;
+  }
+
+  redo(): ActionLog | undefined {
+    const log = this.future.pop();
+    if (log) this.past.push(log);
+    return log;
+  }
+}
+
+const logger = new ActionLogger();
+const history = new ActionHistory();
+
+export function pinToCanvas(messageId: string, leadId: LeadId, canvasId = "default") {
+  const log = logger.log("pin_to_canvas", { messageId, canvasId }, leadId);
+  history.commit(log);
+  return log;
+}
+
+export function editAndRerun(cardId: string, paramsPatch: Record<string, unknown>, leadId: LeadId) {
+  const log = logger.log("edit_and_rerun", { cardId, paramsPatch }, leadId);
+  history.commit(log);
+  return log;
+}
+
+export function makeScenario(cardId: string, variant: "A" | "B" | "C", leadId: LeadId) {
+  const log = logger.log("make_scenario", { cardId, variant }, leadId);
+  history.commit(log);
+  return log;
+}
+
+export function linkCards(fromCardId: string, toCardId: string, leadId: LeadId) {
+  const log = logger.log("link_cards", { fromCardId, toCardId }, leadId);
+  history.commit(log);
+  return log;
+}
+
+export interface AnnotationRegion {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  comment: string;
+}
+
+export function annotate(cardId: string, region: AnnotationRegion, leadId: LeadId) {
+  const log = logger.log("annotation", { cardId, region }, leadId);
+  history.commit(log);
+  return log;
+}
+
+export type ExportFormat = "png" | "pdf" | "json" | "csv";
+
+export function exportService(cardId: string, format: ExportFormat, leadId: LeadId) {
+  const filename = `export-${cardId}-${Date.now()}.${format}`;
+  const log = logger.log("export", { cardId, format, filename }, leadId);
+  history.commit(log);
+  return { log, filename };
+}
+
+export const actionLogger = logger;
+export const actionHistory = history;

--- a/tests/microinteractions.test.ts
+++ b/tests/microinteractions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import {
+  actionHistory,
+  actionLogger,
+  annotate,
+  editAndRerun,
+  exportService,
+  linkCards,
+  makeScenario,
+  pinToCanvas,
+} from "../lib/microinteractions";
+
+describe("microinteraction flow", () => {
+  test("pin → edit → rerun → compare → export", () => {
+    const lead = "lead123";
+    pinToCanvas("msg1", lead);
+    editAndRerun("card1", { temperature: 0.2 }, lead);
+    makeScenario("card1", "A", lead);
+    linkCards("card1", "card2", lead);
+    annotate("card1", { x: 0, y: 0, w: 10, h: 10, comment: "note" }, lead);
+    const { filename } = exportService("card1", "png", lead);
+
+    const history = actionLogger.history();
+    expect(history).toHaveLength(6);
+    expect(filename.startsWith("export-card1")).toBe(true);
+
+    const undone = actionHistory.undo();
+    expect(undone?.type).toBe("export");
+    const redone = actionHistory.redo();
+    expect(redone?.type).toBe("export");
+  });
+});


### PR DESCRIPTION
## Summary
- scaffold global microinteraction actions (pin, edit & rerun, scenario variants, links, annotations, exports)
- add typed logger with idempotency and undo/redo history
- test pin→edit→rerun→compare→export flow

## Testing
- `pnpm exec vitest tests/microinteractions.test.ts`
- `pnpm test` *(fails: 34 did not run, serving HTML report)*
- `pnpm lint` *(fails: lint/a11y/useButtonType and others)*

------
https://chatgpt.com/codex/tasks/task_e_68ba54fa56f88332a804b8a212ef8826