### PR TITLE
feat: add tariff selector component

### DIFF
--- a/apps/web/components/personas/integrator/TariffSelector.test.tsx
+++ b/apps/web/components/personas/integrator/TariffSelector.test.tsx
@@ -1,0 +1,53 @@
+import React, { createRef } from "react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TariffSelector } from "./TariffSelector";
+import { computeIndicators } from "../../../../../packages/ui-cards/FinancialAnalysisCard";
+
+describe("TariffSelector", () => {
+  afterEach(() => {
+    cleanup();
+  });
+  it("filters by UF", async () => {
+    render(<TariffSelector />);
+    const user = userEvent.setup();
+    await user.selectOptions(screen.getByLabelText("UF"), "RJ");
+    const select = screen.getByLabelText("Tarifa/Distribuidora");
+    const options = within(select).getAllByRole("option");
+    // includes 'Selecione' disabled option and RJ Energy
+    expect(options).toHaveLength(2);
+    expect(within(select).queryByText("RJ Energy")).not.toBeNull();
+  });
+
+  it("searches by distributor name", async () => {
+    render(<TariffSelector />);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText("Pesquisa"), "Light");
+    const select = screen.getByLabelText("Tarifa/Distribuidora");
+    expect(within(select).queryByText("MG Light")).not.toBeNull();
+  });
+
+  it("shows validity notice when selecting", async () => {
+    render(<TariffSelector />);
+    const user = userEvent.setup();
+    await user.selectOptions(screen.getByLabelText("Tarifa/Distribuidora"), "sp");
+    expect(screen.getByText(/Vigência até/).textContent).toContain("31/12/2025");
+  });
+
+  it("forwards ref", () => {
+    const ref = createRef<HTMLSelectElement>();
+    render(<TariffSelector ref={ref} />);
+    expect(ref.current).not.toBeNull();
+  });
+
+  it("integrates with financial analysis", async () => {
+    const onSelect = vi.fn();
+    render(<TariffSelector onSelect={onSelect} />);
+    const user = userEvent.setup();
+    await user.selectOptions(screen.getByLabelText("Tarifa/Distribuidora"), "rj");
+    const selected = onSelect.mock.calls[0][0];
+    const { roi } = computeIndicators({ tariff: selected.price, losses: 0, years: 1 });
+    expect(typeof roi).toBe("number");
+  });
+});

--- a/apps/web/components/personas/integrator/TariffSelector.tsx
+++ b/apps/web/components/personas/integrator/TariffSelector.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import React, { forwardRef, useMemo, useState } from "react";
+
+export interface Tariff {
+  id: string;
+  distributor: string;
+  uf: string;
+  price: number;
+  validUntil: string; // ISO date string
+}
+
+const tariffs: Tariff[] = [
+  {
+    id: "sp",
+    distributor: "SP Power",
+    uf: "SP",
+    price: 0.6,
+    validUntil: "2025-12-31",
+  },
+  {
+    id: "rj",
+    distributor: "RJ Energy",
+    uf: "RJ",
+    price: 0.55,
+    validUntil: "2024-06-30",
+  },
+  {
+    id: "mg",
+    distributor: "MG Light",
+    uf: "MG",
+    price: 0.58,
+    validUntil: "2024-12-31",
+  },
+];
+
+export interface TariffSelectorProps {
+  onSelect?: (tariff: Tariff) => void;
+  className?: string;
+}
+
+export const TariffSelector = forwardRef<HTMLSelectElement, TariffSelectorProps>(
+  ({ onSelect, className }, ref) => {
+    const [search, setSearch] = useState("");
+    const [uf, setUf] = useState("");
+    const [selected, setSelected] = useState("");
+
+    const ufs = useMemo(
+      () => Array.from(new Set(tariffs.map((t) => t.uf))).sort(),
+      [],
+    );
+
+    const filtered = useMemo(
+      () =>
+        tariffs.filter(
+          (t) =>
+            (uf === "" || t.uf === uf) &&
+            t.distributor.toLowerCase().includes(search.toLowerCase()),
+        ),
+      [search, uf],
+    );
+
+    const current = tariffs.find((t) => t.id === selected);
+
+    return (
+      <div className={className}>
+        <div className="flex gap-2 mb-2">
+          <label className="flex flex-col text-sm">
+            Pesquisa
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="border p-1 rounded"
+            />
+          </label>
+          <label className="flex flex-col text-sm">
+            UF
+            <select
+              value={uf}
+              onChange={(e) => setUf(e.target.value)}
+              className="border p-1 rounded"
+            >
+              <option value="">Todas</option>
+              {ufs.map((u) => (
+                <option key={u} value={u}>
+                  {u}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+        <label className="flex flex-col text-sm">
+          Tarifa/Distribuidora
+          <select
+            ref={ref}
+            value={selected}
+            onChange={(e) => {
+              setSelected(e.target.value);
+              const tariff = tariffs.find((t) => t.id === e.target.value);
+              if (tariff && onSelect) onSelect(tariff);
+            }}
+            className="border p-1 rounded"
+          >
+            <option value="" disabled>
+              Selecione
+            </option>
+            {filtered.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.distributor}
+              </option>
+            ))}
+          </select>
+        </label>
+        {current && (
+          <p className="mt-1 text-xs text-gray-500">
+            Vigência até {new Date(current.validUntil).toLocaleDateString("pt-BR")}
+          </p>
+        )}
+      </div>
+    );
+  },
+);
+
+TariffSelector.displayName = "TariffSelector";
+
+export default TariffSelector;

--- a/components/persona/integrator.tsx
+++ b/components/persona/integrator.tsx
@@ -12,17 +12,7 @@ export function ConstraintsEditor() {
   return <div className="p-2 border rounded">Constraints Editor</div>;
 }
 
-export function TariffSelector() {
-  return (
-    <div className="flex flex-col gap-1">
-      <label htmlFor="tariff">Tariff</label>
-      <select id="tariff" className="border p-1 rounded">
-        <option>Residential</option>
-        <option>Commercial</option>
-      </select>
-    </div>
-  );
-}
+export { TariffSelector } from "@/apps/web/components/personas/integrator/TariffSelector";
 
 export function PricingRules() {
   return <div className="p-2 border rounded">Pricing Rules</div>;


### PR DESCRIPTION
## Summary
- add integrator tariff selector with search, UF filter, and validity notice
- expose tariff selector through persona module
- cover tariff selector with unit tests

## Testing
- `pnpm lint` (fails: missing button types and other pre-existing lint issues)
- `pnpm exec vitest run apps/web/components/personas/integrator/TariffSelector.test.tsx --environment jsdom`
- `pnpm test` (fails: e2e tests did not complete)

------
https://chatgpt.com/codex/tasks/task_e_68ba55ce78148332b60e8c0ac7bec003