### PR TITLE
feat: add integrator pricing rules component

### DIFF
--- a/apps/web/components/personas/integrator/PricingRules.test.ts
+++ b/apps/web/components/personas/integrator/PricingRules.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { applyPricingRules, priceFromBOM } from './PricingRules';
+
+describe('applyPricingRules', () => {
+  it('calculates totals with markup, logistics and contingency', () => {
+    const result = applyPricingRules(1000, {
+      markup: 0.1,
+      logistics: 50,
+      contingency: 0.05,
+    });
+    expect(result.base).toBe(1000);
+    expect(result.markup).toBe(100);
+    expect(result.logistics).toBe(50);
+    expect(result.contingency).toBe(50);
+    expect(result.total).toBe(1200);
+  });
+});
+
+describe('priceFromBOM', () => {
+  it('sums bom items before applying pricing rules', () => {
+    const result = priceFromBOM(
+      [
+        { name: 'panel', cost: 500 },
+        { name: 'inverter', cost: 300 },
+      ],
+      { markup: 0.1, logistics: 50, contingency: 0.1 },
+    );
+    expect(result.base).toBe(800);
+    expect(result.total).toBeCloseTo(1010);
+  });
+});

--- a/apps/web/components/personas/integrator/PricingRules.tsx
+++ b/apps/web/components/personas/integrator/PricingRules.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+export interface PricingRuleSet {
+  /** percentage markup expressed as decimal (e.g. 0.2 for 20%) */
+  markup: number;
+  /** absolute logistics cost */
+  logistics: number;
+  /** contingency percentage expressed as decimal */
+  contingency: number;
+}
+
+export interface PricingResult {
+  base: number;
+  markup: number;
+  logistics: number;
+  contingency: number;
+  total: number;
+}
+
+/**
+ * applyPricingRules provides an auditable calculation of final price
+ * from a base cost and rule set consisting of markup, logistics and
+ * contingency percentages.
+ */
+export function applyPricingRules(
+  base: number,
+  rules: PricingRuleSet,
+): PricingResult {
+  const markup = base * rules.markup;
+  const contingency = base * rules.contingency;
+  const total = base + markup + rules.logistics + contingency;
+  return { base, markup, logistics: rules.logistics, contingency, total };
+}
+
+export interface BomItem {
+  name: string;
+  cost: number;
+}
+
+/**
+ * priceFromBOM aggregates a bill of materials and applies pricing rules.
+ * The result can be consumed by CostCard or similar components.
+ */
+export function priceFromBOM(
+  items: BomItem[],
+  rules: PricingRuleSet,
+): PricingResult {
+  const base = items.reduce((sum, item) => sum + item.cost, 0);
+  return applyPricingRules(base, rules);
+}
+
+interface PricingRulesProps {
+  items: BomItem[];
+  rules: PricingRuleSet;
+}
+
+/**
+ * PricingRules renders a CAPEX preview based on BOM items and pricing rules.
+ */
+export function PricingRules({ items, rules }: PricingRulesProps) {
+  const result = priceFromBOM(items, rules);
+
+  return (
+    <div>
+      <h3>CAPEX Preview</h3>
+      <ul>
+        <li>
+          Base: ${'{'}result.base.toFixed(2){'}'}
+        </li>
+        <li>
+          Markup ({'{'}(rules.markup * 100).toFixed(1){'}'}%): ${'{'}
+          result.markup.toFixed(2)
+          {'}'}
+        </li>
+        <li>
+          Logistics: ${'{'}result.logistics.toFixed(2){'}'}
+        </li>
+        <li>
+          Contingency ({'{'}(rules.contingency * 100).toFixed(1){'}'}%): ${'{'}
+          result.contingency.toFixed(2)
+          {'}'}
+        </li>
+        <li>
+          Total: ${'{'}result.total.toFixed(2){'}'}
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+export default PricingRules;


### PR DESCRIPTION
## Summary
- add auditable pricing rules component for integrators with CAPEX preview
- include helpers to apply markup, logistics and contingency to BOM items
- cover pricing formulas with unit tests

## Testing
- `pnpm format apps/web/components/personas/integrator/PricingRules.tsx apps/web/components/personas/integrator/PricingRules.test.ts`
- `pnpm exec vitest apps/web/components/personas/integrator/PricingRules.test.ts`
- `pnpm test` *(fails: 30 failed, 34 did not run)*
- `pnpm lint` *(fails: a11y/useButtonType, noStaticElementInteractions, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ba55e1dc508332ba85528bfd420428