### PR TITLE
feat: add link embedder

### DIFF
--- a/apps/web/components/multimodal/LinkEmbedder.tsx
+++ b/apps/web/components/multimodal/LinkEmbedder.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import DOMPurify from 'dompurify';
+
+interface LinkEmbedderProps {
+  url: string;
+}
+
+interface OEmbedData {
+  html?: string;
+  title?: string;
+  thumbnail_url?: string;
+}
+
+export function LinkEmbedder({ url }: LinkEmbedderProps) {
+  const [data, setData] = useState<OEmbedData | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    async function load() {
+      try {
+        const res = await fetch(
+          `https://noembed.com/embed?url=${encodeURIComponent(url)}`,
+        );
+        if (!res.ok) return;
+        const json = (await res.json()) as OEmbedData;
+        if (active) setData(json);
+      } catch {
+        // ignore network errors
+      }
+    }
+    load();
+    return () => {
+      active = false;
+    };
+  }, [url]);
+
+  if (data) {
+    if (data.html) {
+      let html = DOMPurify.sanitize(data.html);
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      doc.querySelectorAll('iframe').forEach((iframe) => {
+        if (!iframe.getAttribute('title') && data.title) {
+          iframe.setAttribute('title', data.title);
+        }
+        iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+      });
+      html = doc.body.innerHTML;
+      return <div dangerouslySetInnerHTML={{ __html: html }} />;
+    }
+    if (data.thumbnail_url) {
+      return (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 underline"
+        >
+          <img
+            src={data.thumbnail_url}
+            alt={data.title ?? 'Link preview'}
+            className="w-16 h-16 object-cover rounded"
+          />
+          <span className="flex-1 break-words">{data.title ?? url}</span>
+        </a>
+      );
+    }
+  }
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline break-words"
+    >
+      {url}
+    </a>
+  );
+}
+
+export default LinkEmbedder;

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "codemirror": "^6.0.1",
     "date-fns": "^4.1.0",
     "diff-match-patch": "^1.0.5",
+    "dompurify": "^3.2.6",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.34.0",
     "embla-carousel-react": "^8.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       diff-match-patch:
         specifier: ^1.0.5
         version: 1.0.5
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.2.6
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7


### PR DESCRIPTION
## Summary
- embed external links with oEmbed previews and sanitization
- add dompurify dependency

## Testing
- `pnpm lint` (fails: Provide an explicit type prop for the button element)
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba566f345c8332850325b1aa168281