### PR TITLE
feat: add solar workflow blueprint

### DIFF
--- a/app/journey/[phase]/page.tsx
+++ b/app/journey/[phase]/page.tsx
@@ -2,6 +2,7 @@
 import { PhaseGuard } from '@/apps/web/lib/journey/guard';
 import { usePhase, useJourneyActions } from '@/apps/web/lib/journey/hooks';
 import type { Phase } from '@/apps/web/lib/journey/map';
+import { blueprint } from '@/apps/web/lib/journey/blueprint';
 
 export default function Page({ params }: { params: { phase: Phase } }) {
   return (
@@ -14,9 +15,19 @@ export default function Page({ params }: { params: { phase: Phase } }) {
 function PhaseView() {
   const phase = usePhase();
   const { next, prev, skip, reset } = useJourneyActions();
+  const nodes = blueprint[phase] ?? [];
   return (
     <div>
       <h1>{phase}</h1>
+      {nodes.length > 0 && (
+        <ul>
+          {nodes.map((n) => (
+            <li key={n.id}>
+              <strong>{n.type === 'input' ? 'Input' : 'Output'}:</strong> {n.label} - {n.description}
+            </li>
+          ))}
+        </ul>
+      )}
       <button id="prev" onClick={prev}>
         Prev
       </button>

--- a/apps/web/lib/journey/blueprint.ts
+++ b/apps/web/lib/journey/blueprint.ts
@@ -1,0 +1,67 @@
+import type { Phase } from './map';
+
+export interface Node {
+  id: string;
+  type: 'input' | 'output';
+  label: string;
+  description: string;
+}
+
+export const blueprint: Partial<Record<Phase, Node[]>> = {
+  Dimensioning: [
+    {
+      id: 'site-data',
+      type: 'input',
+      label: 'Dados do local',
+      description: 'Usuário informa parâmetros do local e consumo energético.',
+    },
+    {
+      id: 'system-sizing',
+      type: 'output',
+      label: 'Dimensionamento do sistema',
+      description: 'Sistema calcula a configuração ideal do sistema solar.',
+    },
+  ],
+  Simulation: [
+    {
+      id: 'simulation-parameters',
+      type: 'input',
+      label: 'Parâmetros de simulação',
+      description: 'Usuário ajusta dados de irradiação e performance.',
+    },
+    {
+      id: 'performance-report',
+      type: 'output',
+      label: 'Relatório de desempenho',
+      description: 'Sistema gera previsões de geração e economia.',
+    },
+  ],
+  Installation: [
+    {
+      id: 'install-schedule',
+      type: 'input',
+      label: 'Agendamento da instalação',
+      description: 'Usuário confirma cronograma e equipe responsável.',
+    },
+    {
+      id: 'installation-plan',
+      type: 'output',
+      label: 'Plano de instalação',
+      description: 'Sistema fornece instruções e lista de materiais.',
+    },
+  ],
+  Monitoring: [
+    {
+      id: 'monitoring-prefs',
+      type: 'input',
+      label: 'Preferências de monitoramento',
+      description: 'Usuário define métricas e alertas.',
+    },
+    {
+      id: 'dashboard',
+      type: 'output',
+      label: 'Painel de monitoramento',
+      description: 'Sistema exibe desempenho em tempo real.',
+    },
+  ],
+};

--- a/apps/web/lib/journey/map.ts
+++ b/apps/web/lib/journey/map.ts
@@ -3,6 +3,9 @@ export type Phase =
   | 'Detection'
   | 'Analysis'
   | 'Dimensioning'
+  | 'Simulation'
+  | 'Installation'
+  | 'Monitoring'
   | 'Recommendation'
   | 'LeadMgmt';
 
@@ -33,12 +36,30 @@ export const journeyMap: Record<Phase, PhaseConfig> = {
   },
   Dimensioning: {
     prev: 'Analysis',
-    next: 'Recommendation',
+    next: 'Simulation',
     cards: ['Dimensioning'],
     viewers: [],
   },
-  Recommendation: {
+  Simulation: {
     prev: 'Dimensioning',
+    next: 'Installation',
+    cards: ['Simulation'],
+    viewers: [],
+  },
+  Installation: {
+    prev: 'Simulation',
+    next: 'Monitoring',
+    cards: ['Installation'],
+    viewers: [],
+  },
+  Monitoring: {
+    prev: 'Installation',
+    next: 'Recommendation',
+    cards: ['Monitoring'],
+    viewers: [],
+  },
+  Recommendation: {
+    prev: 'Monitoring',
     next: 'LeadMgmt',
     cards: ['Recommendation'],
     viewers: [],
@@ -55,6 +76,9 @@ export const phases: Phase[] = [
   'Detection',
   'Analysis',
   'Dimensioning',
+  'Simulation',
+  'Installation',
+  'Monitoring',
   'Recommendation',
   'LeadMgmt',
 ];


### PR DESCRIPTION
## Summary
- extend journey map with Simulation, Installation and Monitoring phases
- document solar workflow inputs and outputs
- render phase nodes using new blueprint data

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf3ea9af4c833280ccff652581ae34