### PR TITLE
feat: add backend microservices skeleton

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,0 +1,6 @@
+# Backend Microservices
+
+This directory contains microservices that expose conversation output APIs.
+
+- `rest`: REST API endpoints.
+- `graphql`: GraphQL API server.

--- a/apps/backend/graphql/README.md
+++ b/apps/backend/graphql/README.md
@@ -1,0 +1,3 @@
+# GraphQL API Service
+
+Microservice exposing a GraphQL endpoint for conversation outputs.

--- a/apps/backend/graphql/package.json
+++ b/apps/backend/graphql/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@ai-ysh/graphql-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node --loader tsx src/index.ts"
+  },
+  "dependencies": {
+    "graphql": "^16.8.1",
+    "@apollo/server": "^4.10.0"
+  }
+}

--- a/apps/backend/graphql/src/index.ts
+++ b/apps/backend/graphql/src/index.ts
@@ -1,0 +1,20 @@
+import { ApolloServer } from '@apollo/server';
+import { startStandaloneServer } from '@apollo/server/standalone';
+
+const typeDefs = `#graphql
+  type Query {
+    health: String!
+  }
+`;
+
+const resolvers = {
+  Query: {
+    health: () => 'ok',
+  },
+};
+
+const server = new ApolloServer({ typeDefs, resolvers });
+
+startStandaloneServer(server, { listen: { port: 4000 } }).then(({ url }) => {
+  console.log(`GraphQL API server ready at ${url}`);
+});

--- a/apps/backend/rest/README.md
+++ b/apps/backend/rest/README.md
@@ -1,0 +1,3 @@
+# REST API Service
+
+Microservice exposing REST endpoints for conversation outputs.

--- a/apps/backend/rest/package.json
+++ b/apps/backend/rest/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@ai-ysh/rest-api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node --loader tsx src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/apps/backend/rest/src/index.ts
+++ b/apps/backend/rest/src/index.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+
+const app = express();
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(3000, () => {
+  console.log('REST API server listening on port 3000');
+});


### PR DESCRIPTION
## Summary
- scaffold backend microservices directory
- add Express-based REST API skeleton
- add Apollo Server GraphQL API skeleton

## Testing
- `pnpm test` *(fails: tests did not run, manual termination)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4037c4f883328fbb299df417c7dd