### PR TITLE
feat: add router agent

### DIFF
--- a/lib/ai/agents/router-agent.test.ts
+++ b/lib/ai/agents/router-agent.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { route, type HostContext } from './router-agent';
+
+describe('RouterAgent', () => {
+  const baseCtx: HostContext = {
+    persona: { mode: 'guest', permissions: [], featureFlags: {} },
+    auth: { quota: { usedToday: 0, limit: 20 } },
+    providers: {
+      gateway: 'vercel',
+      defaultModel: 'grok-3-mini-beta',
+      fallbacks: ['gpt-4.1-mini', 'claude-3.5-sonnet'],
+    },
+  };
+
+  it('seleciona modelo leve para convidados', () => {
+    const res = route('Olá', baseCtx);
+    expect(res.model_hint).toBe('grok-3-mini-beta');
+  });
+
+  it('seleciona modelo avançado para usuários regulares e detecta intenção de vendas', () => {
+    const ctx: HostContext = {
+      ...baseCtx,
+      persona: { ...baseCtx.persona, mode: 'regular' },
+    };
+    const res = route('Quero comprar um sistema', ctx);
+    expect(res.model_hint).toBe('gpt-4.1');
+    expect(res.intent).toBe('sales/presales');
+  });
+
+  it('bloqueia quando a cota é excedida', () => {
+    const ctx: HostContext = {
+      ...baseCtx,
+      auth: { quota: { usedToday: 20, limit: 20 } },
+    };
+    const res = route('Qualquer coisa', ctx);
+    expect(res.reply).toMatch(/cota diária/);
+    expect(res.next_agent).toBe('self');
+  });
+});

--- a/lib/ai/agents/router-agent.ts
+++ b/lib/ai/agents/router-agent.ts
@@ -1,0 +1,111 @@
+/**
+ * Agente Roteador Omnicanal
+ * Responsável por identificar intenção, selecionar modelo e encaminhar para próximos agentes
+ */
+
+export type RouterIntent =
+  | 'sales/presales'
+  | 'support/tech'
+  | 'billing/finance'
+  | 'lead/qualification'
+  | 'appointment/schedule'
+  | 'other';
+
+export type PersonaMode = 'owner' | 'integrator' | 'guest' | 'regular';
+
+export type NextAgent =
+  | 'investigation'
+  | 'detection'
+  | 'analysis'
+  | 'dimensioning'
+  | 'recommendation'
+  | 'support'
+  | 'billing'
+  | 'self';
+
+export interface RouterAction {
+  tool: string;
+  args: Record<string, unknown>;
+  why: string;
+}
+
+export interface RouterResponse {
+  intent: RouterIntent;
+  persona_mode: PersonaMode;
+  model_hint: string;
+  next_agent: NextAgent;
+  actions: RouterAction[];
+  reply: string;
+  follow_up: string[];
+}
+
+export interface HostContext {
+  persona: {
+    mode: PersonaMode;
+    permissions: string[];
+    featureFlags: Record<string, boolean>;
+  };
+  auth: {
+    userId?: string;
+    quota: { usedToday: number; limit: number };
+  };
+  providers: {
+    gateway: string;
+    defaultModel: string;
+    fallbacks: string[];
+  };
+}
+
+function detectIntent(message: string): RouterIntent {
+  const text = message.toLowerCase();
+  if (/venda|preço|proposta|comprar/.test(text)) return 'sales/presales';
+  if (/suporte|técnico|erro|bug/.test(text)) return 'support/tech';
+  if (/fatura|boleto|pagamento|cobrança/.test(text)) return 'billing/finance';
+  if (/lead|prospect|qualifica/.test(text)) return 'lead/qualification';
+  if (/agendar|agenda|marcar|horário/.test(text)) return 'appointment/schedule';
+  return 'other';
+}
+
+function selectModel(ctx: HostContext): string {
+  return ctx.persona.mode === 'guest' ? ctx.providers.defaultModel : 'gpt-4.1';
+}
+
+function selectNextAgent(intent: RouterIntent): NextAgent {
+  switch (intent) {
+    case 'support/tech':
+      return 'support';
+    case 'billing/finance':
+      return 'billing';
+    default:
+      return 'analysis';
+  }
+}
+
+export function route(message: string, ctx: HostContext): RouterResponse {
+  const modelHint = selectModel(ctx);
+
+  if (ctx.auth.quota.usedToday >= ctx.auth.quota.limit) {
+    return {
+      intent: 'other',
+      persona_mode: ctx.persona.mode,
+      model_hint: modelHint,
+      next_agent: 'self',
+      actions: [],
+      reply: 'Desculpe, sua cota diária foi atingida. Tente novamente amanhã.',
+      follow_up: ['Tentar novamente amanhã', 'Falar com nosso time de suporte'],
+    };
+  }
+
+  const intent = detectIntent(message);
+  const nextAgent = selectNextAgent(intent);
+
+  return {
+    intent,
+    persona_mode: ctx.persona.mode,
+    model_hint: modelHint,
+    next_agent: nextAgent,
+    actions: [],
+    reply: `Solicitação encaminhada para ${nextAgent}.`,
+    follow_up: ['Precisa de mais alguma coisa?', 'Ver opções disponíveis'],
+  };
+}


### PR DESCRIPTION
## Summary
- add router agent for intent detection and routing
- add unit tests for model selection and quota handling

## Testing
- `npx vitest lib/ai/agents/router-agent.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c10ad6fdac833296c3940ee7630ab7