### PR TITLE
feat: add omnichannel service scaffolding

### DIFF
--- a/lib/services/omnichannel-service.ts
+++ b/lib/services/omnichannel-service.ts
@@ -1,0 +1,177 @@
+import { nanoid } from "nanoid";
+
+export interface CampaignPlan {
+	campaign: {
+		name: string;
+		objective: string;
+		audience_size: number;
+		persona_mode: string;
+		schedule_window: {
+			start_iso: string;
+			end_iso: string;
+			timezone: string;
+		};
+	};
+	content: {
+		variant_A: { headline: string; body: string; cta: string };
+		variant_B: { headline: string; body: string; cta: string };
+	};
+	channels: Array<{
+		type: string;
+		template?: string | null;
+		rate?: string;
+		enable: boolean;
+		subject?: string;
+	}>;
+	actions: Array<{ tool: string; args: Record<string, any>; why: string }>;
+	kpis: {
+		deliverability_target: number;
+		ctr_target: number;
+		reply_rate_target: number;
+	};
+	reply: string;
+}
+
+export class OmnichannelService {
+	async complianceCheck(payload: string) {
+		console.log("compliance_check", payload);
+		return { id: nanoid(), status: "checked" };
+	}
+
+	async rateLimit(key: string, quotaPerWindow: number) {
+		console.log("rate_limit", { key, quotaPerWindow });
+		return { key, quotaPerWindow, status: "scheduled" };
+	}
+
+	async sendWhatsappMCP(
+		to: string,
+		text: string,
+		media?: string,
+		templateId?: string,
+	) {
+		console.log("send_whatsapp_mcp", { to, text, media, templateId });
+		return { to, status: "queued" };
+	}
+
+	async sendTelegram(to: string, text: string, media?: string) {
+		console.log("send_telegram", { to, text, media });
+		return { to, status: "queued" };
+	}
+
+	async sendEmail(to: string, subject: string, html: string) {
+		console.log("send_email", { to, subject });
+		return { to, subject, status: "queued" };
+	}
+
+	async sendSmsTwilio(to: string, text: string) {
+		console.log("send_sms_twilio", { to, text });
+		return { to, status: "queued" };
+	}
+
+	async sendVoiceTwilio(to: string, ttsScript: string) {
+		console.log("send_voice_twilio", { to, ttsScript });
+		return { to, status: "queued" };
+	}
+
+	async sendTwitterDM(toHandle: string, text: string) {
+		console.log("send_twitter_dm", { toHandle, text });
+		return { toHandle, status: "queued" };
+	}
+
+	async postTwitter(status: string, media?: string) {
+		console.log("post_twitter", { status, media });
+		return { status, id: nanoid() };
+	}
+
+	async shortlinkCreate(url: string) {
+		console.log("shortlink_create", { url });
+		return { shortUrl: `https://sho.rt/${nanoid(6)}` };
+	}
+
+	async kbSearch(query: string) {
+		console.log("kb_search", { query });
+		return [];
+	}
+
+	async scheduleCreate(
+		type: string,
+		datetime: string,
+		payload: Record<string, any>,
+	) {
+		console.log("schedule_create", { type, datetime, payload });
+		return { id: nanoid(), status: "scheduled" };
+	}
+
+	async crmUpsert(entity: string, data: Record<string, any>) {
+		console.log("crm_upsert", { entity, data });
+		return { entity, id: nanoid(), status: "upserted" };
+	}
+
+	async executeAction(action: {
+		tool: string;
+		args: Record<string, any>;
+		why: string;
+	}) {
+		switch (action.tool) {
+			case "compliance_check":
+				return this.complianceCheck(action.args.payload);
+			case "rate_limit":
+				return this.rateLimit(action.args.key, action.args.quota_per_window);
+			case "send_whatsapp_mcp":
+				return this.sendWhatsappMCP(
+					action.args.to,
+					action.args.text,
+					action.args.media,
+					action.args.templateId,
+				);
+			case "send_email":
+				return this.sendEmail(
+					action.args.to,
+					action.args.subject,
+					action.args.html,
+				);
+			case "send_telegram":
+				return this.sendTelegram(
+					action.args.to,
+					action.args.text,
+					action.args.media,
+				);
+			case "send_sms_twilio":
+				return this.sendSmsTwilio(action.args.to, action.args.text);
+			case "send_voice_twilio":
+				return this.sendVoiceTwilio(action.args.to, action.args.tts_script);
+			case "send_twitter_dm":
+				return this.sendTwitterDM(action.args.to_handle, action.args.text);
+			case "post_twitter":
+				return this.postTwitter(action.args.status, action.args.media);
+			case "shortlink_create":
+				return this.shortlinkCreate(action.args.url);
+			case "kb_search":
+				return this.kbSearch(action.args.query);
+			case "schedule_create":
+				return this.scheduleCreate(
+					action.args.type,
+					action.args.datetime,
+					action.args.payload,
+				);
+			case "crm_upsert":
+				return this.crmUpsert(action.args.entity, action.args.data);
+			default:
+				throw new Error(`Unsupported action: ${action.tool}`);
+		}
+	}
+
+	async runCampaign(plan: CampaignPlan) {
+		const results = [] as any[];
+		for (const action of plan.actions) {
+			// eslint-disable-next-line no-await-in-loop
+			const res = await this.executeAction(action);
+			results.push(res);
+		}
+		return results;
+	}
+}
+
+export const omnichannelService = new OmnichannelService();
+
+export default OmnichannelService;

--- a/tests/omnichannel-service.test.ts
+++ b/tests/omnichannel-service.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import {
+	OmnichannelService,
+	CampaignPlan,
+} from "../lib/services/omnichannel-service";
+
+describe("OmnichannelService", () => {
+	test("runCampaign executes actions sequentially", async () => {
+		const plan: CampaignPlan = {
+			campaign: {
+				name: "test",
+				objective: "leadgen",
+				audience_size: 1,
+				persona_mode: "mixed",
+				schedule_window: {
+					start_iso: "2025-01-01T00:00:00",
+					end_iso: "2025-01-01T00:00:00",
+					timezone: "America/Sao_Paulo",
+				},
+			},
+			content: {
+				variant_A: { headline: "", body: "hi", cta: "" },
+				variant_B: { headline: "", body: "hi", cta: "" },
+			},
+			channels: [],
+			actions: [
+				{ tool: "compliance_check", args: { payload: "test" }, why: "ensure" },
+				{
+					tool: "send_email",
+					args: {
+						to: "user@example.com",
+						subject: "Hello",
+						html: "<p>Hello</p>",
+					},
+					why: "notify",
+				},
+			],
+			kpis: { deliverability_target: 0, ctr_target: 0, reply_rate_target: 0 },
+			reply: "",
+		};
+
+		const service = new OmnichannelService();
+		const result = await service.runCampaign(plan);
+		expect(result).toHaveLength(2);
+	});
+});


### PR DESCRIPTION
## Summary
- add OmnichannelService to centralize multi-channel actions
- cover campaign execution with a basic unit test

## Testing
- `pnpm lint` *(fails: Storybook renderer import errors)*
- `pnpm test` *(fails: Vitest cannot be imported in CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68c110d9973c8332b9881be3407c14e1