### PR TITLE
feat(omni): redis streams bus (publish/read)

### DIFF
--- a/lib/omni/bus.test.ts
+++ b/lib/omni/bus.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+vi.mock("./redis", () => ({
+  redis: {
+    sendCommand: vi.fn(),
+  },
+}));
+
+import { publish, read } from "./bus";
+import { redis } from "./redis";
+import type { MessageCanonical } from "./message";
+
+const mock = redis.sendCommand as unknown as Mock;
+
+describe("omni bus", () => {
+  beforeEach(() => {
+    mock.mockReset();
+  });
+
+  it("publishes message", async () => {
+    mock.mockResolvedValueOnce("OK").mockResolvedValueOnce("1-0");
+    const msg = { trace: { trace_id: "t1" }, payload: { foo: "bar" } };
+    const id = await publish("stream", msg);
+    expect(id).toBe("1-0");
+    expect(mock.mock.calls[0][0][0]).toBe("SET");
+    expect(mock.mock.calls[1][0][0]).toBe("XADD");
+  });
+
+  it("dedups by trace id", async () => {
+    mock.mockResolvedValueOnce(null);
+    const msg = { trace: { trace_id: "t1" }, payload: {} };
+    const id = await publish("stream", msg);
+    expect(id).toBeNull();
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads messages and ack", async () => {
+    const message = { trace: { trace_id: "t2" }, payload: { a: 1 } };
+    mock.mockResolvedValueOnce([
+      ["stream", [["1-0", ["data", JSON.stringify(message)]]]],
+    ]);
+    const [item] = await read({
+      stream: "stream",
+      group: "group",
+      consumer: "c",
+      blockMs: 1,
+    });
+    expect(item.message).toEqual(message);
+    mock.mockResolvedValueOnce(1);
+    await item.ack();
+    expect(mock.mock.calls[1][0][0]).toBe("XACK");
+  });
+
+  it("fails to publish invalid payload", async () => {
+    const bad = { foo: "bar" } as unknown as MessageCanonical;
+    await expect(publish("stream", bad)).rejects.toBeTruthy();
+  });
+});

--- a/lib/omni/bus.ts
+++ b/lib/omni/bus.ts
@@ -1,0 +1,84 @@
+import { redis } from "./redis";
+import type { MessageCanonical } from "./message";
+import { MessageCanonicalSchema } from "./message";
+import { DEDUP_TTL } from "./constants";
+
+export async function publish(
+  stream: string,
+  message: MessageCanonical,
+  maxlen?: number,
+): Promise<string | null> {
+  const parsed = MessageCanonicalSchema.parse(message);
+  if (parsed.trace?.trace_id) {
+    const key = `omni:trace:${parsed.trace.trace_id}`;
+    const res = await redis.sendCommand([
+      "SET",
+      key,
+      "1",
+      "PX",
+      String(DEDUP_TTL),
+      "NX",
+    ]);
+    if (res === null) return null;
+  }
+
+  const payload = JSON.stringify(parsed);
+  const args = ["XADD", stream];
+  if (maxlen) {
+    args.push("MAXLEN", "~", String(maxlen));
+  }
+  args.push("*", "data", payload);
+  const id = (await redis.sendCommand(args)) as string;
+  return id;
+}
+
+interface ReadOptions {
+  stream: string;
+  group: string;
+  consumer: string;
+  blockMs?: number;
+  count?: number;
+}
+
+interface StreamMessage {
+  id: string;
+  message: MessageCanonical;
+  ack: () => Promise<unknown>;
+}
+
+export async function read(options: ReadOptions): Promise<StreamMessage[]> {
+  const { stream, group, consumer, blockMs = 0, count = 1 } = options;
+  const args = [
+    "XREADGROUP",
+    "GROUP",
+    group,
+    consumer,
+    "COUNT",
+    String(count),
+  ];
+  if (blockMs) {
+    args.push("BLOCK", String(blockMs));
+  }
+  args.push("STREAMS", stream, ">");
+  type XReadGroupResult = [string, [string, string[]][]][];
+  const res = (await redis.sendCommand(args)) as XReadGroupResult | null;
+  if (!res) return [];
+
+  const messages: StreamMessage[] = [];
+  for (const [, entries] of res) {
+    for (const [id, fields] of entries) {
+      const dataIndex = fields.findIndex(
+        (v: string, i: number) => i % 2 === 0 && v === "data",
+      );
+      const raw = fields[dataIndex + 1];
+      const parsed = MessageCanonicalSchema.parse(JSON.parse(raw));
+      messages.push({
+        id,
+        message: parsed,
+        ack: () =>
+          redis.sendCommand(["XACK", stream, group, id]) as Promise<unknown>,
+      });
+    }
+  }
+  return messages;
+}

--- a/lib/omni/constants.ts
+++ b/lib/omni/constants.ts
@@ -1,0 +1,10 @@
+import { nanoid } from "nanoid";
+
+export const STREAM_MESSAGES =
+  process.env.OMNI_STREAM_MESSAGES ?? "omni.messages";
+export const STREAM_OUTBOX =
+  process.env.OMNI_STREAM_OUTBOX ?? "omni.outbox";
+export const GROUP = process.env.OMNI_GROUP ?? "omni-core";
+export const CONSUMER = process.env.OMNI_CONSUMER ?? `consumer-${nanoid()}`;
+export const BLOCK_MS = Number(process.env.OMNI_BLOCK_MS ?? "5000");
+export const DEDUP_TTL = Number(process.env.OMNI_DEDUP_TTL ?? "60000");

--- a/lib/omni/message.ts
+++ b/lib/omni/message.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const TraceSchema = z.object({
+  trace_id: z.string(),
+});
+
+export const MessageCanonicalSchema = z.object({
+  trace: TraceSchema,
+  payload: z.any(),
+});
+
+export type MessageCanonical = z.infer<typeof MessageCanonicalSchema>;

--- a/lib/omni/redis.ts
+++ b/lib/omni/redis.ts
@@ -1,0 +1,27 @@
+import { createClient } from "redis";
+
+const url = process.env.REDIS_URL ?? "redis://localhost:6379";
+
+export const redis = createClient({
+  url,
+  socket: {
+    reconnectStrategy: (retries) => Math.min(retries * 50, 5000),
+  },
+});
+
+redis.on("error", (err) => {
+  console.error("Redis error", err);
+});
+
+void redis.connect();
+
+const shutdown = async () => {
+  try {
+    await redis.quit();
+  } catch {
+    // noop
+  }
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);


### PR DESCRIPTION
## Summary
- add Redis Streams bus with publish/read helpers and ack support
- expose Omni stream/group constants and resilient Redis client
- cover publish/read behavior with unit tests

## Testing
- `npx eslint lib/omni/*.ts lib/omni/*.test.ts`
- `npx biome lint lib/omni/*.ts lib/omni/*.test.ts`
- `npx vitest run lib/omni/bus.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c11e0aceec83328fa9c733e3e83533