### PR TITLE
feat(whatsapp): mcp bridge + echo wa→web

### DIFF
--- a/adapters/bridge/echo-web.ts
+++ b/adapters/bridge/echo-web.ts
@@ -1,0 +1,13 @@
+import type { MessageCanonical } from '../whatsapp/mcp-client';
+
+/**
+ * Creates a web outbound message that echoes the WhatsApp inbound content.
+ */
+export function echoWeb(message: MessageCanonical): MessageCanonical {
+  return {
+    ...message,
+    id: `${message.id}-web`,
+    direction: 'out',
+    channel: 'web',
+  };
+}

--- a/adapters/whatsapp/mcp-client.ts
+++ b/adapters/whatsapp/mcp-client.ts
@@ -1,0 +1,75 @@
+import { EventEmitter } from 'node:events';
+import { randomUUID } from 'node:crypto';
+
+export interface MessageCanonical {
+  id: string;
+  direction: 'in' | 'out';
+  channel: string;
+  type: string;
+  text?: string;
+  mediaUrl?: string;
+}
+
+export interface WhatsAppEvent {
+  id?: string;
+  type: string;
+  text?: string;
+  mediaUrl?: string;
+}
+
+/**
+ * Minimal WhatsApp MCP client.
+ *
+ * In a real environment this connects to the MCP server via WebSocket and
+ * emits canonical messages. For local development or tests the `simulate`
+ * method can be used to feed synthetic events.
+ */
+export class WhatsAppMCPClient extends EventEmitter {
+  // biome-ignore lint/suspicious/noExplicitAny: WebSocket instance is provided by the runtime
+  private ws?: any;
+
+  constructor(private url: string, private token: string) {
+    super();
+  }
+
+  /**
+   * Connects to the MCP server using the global WebSocket implementation when
+   * available. This is a best-effort implementation so the code remains runnable
+   * without additional dependencies during tests.
+   */
+  async connect(): Promise<void> {
+    // biome-ignore lint/suspicious/noExplicitAny: accessing global WebSocket
+    const WebSocketImpl: any = (globalThis as any).WebSocket;
+    if (!WebSocketImpl) {
+      throw new Error('WebSocket implementation not found');
+    }
+    this.ws = new WebSocketImpl(this.url, {
+      headers: { Authorization: `Bearer ${this.token}` },
+    });
+    this.ws.onmessage = (event: MessageEvent) => {
+      try {
+        const payload: WhatsAppEvent = JSON.parse(String(event.data));
+        this.emit('message', this.normalize(payload));
+      } catch (err) {
+        this.emit('error', err);
+      }
+    };
+  }
+
+  /** Normalizes a raw WhatsApp event into the canonical format. */
+  private normalize(event: WhatsAppEvent): MessageCanonical {
+    return {
+      id: event.id ?? randomUUID(),
+      direction: 'in',
+      channel: 'whatsapp',
+      type: event.type,
+      text: event.text,
+      mediaUrl: event.mediaUrl,
+    };
+  }
+
+  /** Utility used in tests to emit synthetic events. */
+  simulate(event: WhatsAppEvent): void {
+    this.emit('message', this.normalize(event));
+  }
+}

--- a/config/docker/compose.omni.yml
+++ b/config/docker/compose.omni.yml
@@ -1,0 +1,29 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+  whatsapp-mcp:
+    image: ghcr.io/openai/whatsapp-mcp:latest
+    environment:
+      MCP_TOKEN: ${MCP_TOKEN}
+    ports:
+      - "8080:8080"
+
+  bridge:
+    image: node:20
+    working_dir: /app
+    command: ["npx", "tsx", "scripts/dev-bridge.ts"]
+    environment:
+      REDIS_URL: redis://redis:6379
+      MCP_WHATSAPP_URL: ws://whatsapp-mcp:8080
+      MCP_TOKEN: ${MCP_TOKEN}
+    depends_on:
+      - redis
+      - whatsapp-mcp
+    volumes:
+      - ../../:/app
+      - /app/node_modules

--- a/scripts/dev-bridge.ts
+++ b/scripts/dev-bridge.ts
@@ -1,0 +1,37 @@
+import { createClient } from 'redis';
+import { WhatsAppMCPClient, type MessageCanonical } from '../adapters/whatsapp/mcp-client';
+import { echoWeb } from '../adapters/bridge/echo-web';
+
+async function main(): Promise<void> {
+  const redis = createClient({ url: process.env.REDIS_URL ?? 'redis://localhost:6379' });
+  await redis.connect();
+
+  const mcp = new WhatsAppMCPClient(
+    process.env.MCP_WHATSAPP_URL ?? 'ws://whatsapp-mcp:8080',
+    process.env.MCP_TOKEN ?? 'dev-token',
+  );
+
+  mcp.on('message', async (msg: MessageCanonical) => {
+    await redis.xAdd('omni.messages', '*', { data: JSON.stringify(msg) });
+    const echo = echoWeb(msg);
+    await redis.xAdd('omni.outbox', '*', { data: JSON.stringify(echo) });
+    console.log('echoed', echo);
+  });
+
+  if (process.env.SIMULATE === '1') {
+    // Simulate both a text and an image message for local testing.
+    mcp.simulate({ type: 'text', text: 'hello from wa' });
+    mcp.simulate({ type: 'image', mediaUrl: 'http://example.com/image.jpg' });
+    // give some time for redis writes then quit
+    setTimeout(async () => {
+      await redis.quit();
+    }, 500);
+  } else {
+    await mcp.connect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add minimal WhatsApp MCP client and bridge echo transformer
- wire dev bridge script to publish MCP events to redis streams
- compose file for redis, whatsapp-mcp and bridge services

## Testing
- `pnpm exec eslint adapters/whatsapp/mcp-client.ts adapters/bridge/echo-web.ts scripts/dev-bridge.ts && echo ESLintOK`
- `pnpm exec biome lint adapters/whatsapp/mcp-client.ts adapters/bridge/echo-web.ts scripts/dev-bridge.ts config/docker/compose.omni.yml && echo BiomeOK`
- `SIMULATE=1 npx tsx scripts/dev-bridge.ts`
- `redis-cli XLEN omni.messages`
- `redis-cli XLEN omni.outbox`
- `redis-cli XRANGE omni.messages - +`
- `redis-cli XRANGE omni.outbox - +`


------
https://chatgpt.com/codex/tasks/task_e_68c11e57d73c8332ae7ece65b856b18a