### PR TITLE
feat(dispatcher): outbox to adapters (whatsapp)

### DIFF
--- a/adapters/whatsapp/sender.ts
+++ b/adapters/whatsapp/sender.ts
@@ -1,0 +1,16 @@
+export interface WhatsAppMessage {
+  to: { contact: string };
+  text: string;
+  media?: string;
+  templateId?: string;
+}
+
+/**
+ * sendWhatsappMCP simulates sending a WhatsApp message through MCP.
+ * In production this should call the actual MCP bridge.
+ */
+export async function sendWhatsappMCP(msg: WhatsAppMessage): Promise<{ status: string }>{
+  console.log("send_whatsapp_mcp", msg);
+  // Placeholder for MCP integration
+  return { status: "sent" };
+}

--- a/lib/omni/dispatch.ts
+++ b/lib/omni/dispatch.ts
@@ -1,0 +1,23 @@
+import { sendWhatsappMCP, type WhatsAppMessage } from "../../adapters/whatsapp/sender";
+
+export interface OutboxMessage {
+  to: { kind: string; contact: string; route?: { adapter?: string } };
+  text: string;
+  media?: string;
+  templateId?: string;
+}
+
+/** Route outgoing messages to the proper adapter */
+export async function dispatch(msg: OutboxMessage) {
+  if (msg.to.kind === "whatsapp") {
+    const wa: WhatsAppMessage = {
+      to: { contact: msg.to.contact },
+      text: msg.text,
+      media: msg.media,
+      templateId: msg.templateId,
+    };
+    await sendWhatsappMCP(wa);
+  } else {
+    throw new Error(`no adapter for kind ${msg.to.kind}`);
+  }
+}

--- a/workers/dispatcher.test.ts
+++ b/workers/dispatcher.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Dispatcher } from "./dispatcher";
+import * as whatsapp from "../adapters/whatsapp/sender";
+
+interface PendingInfo {
+  consumer: string;
+  timestamp: number;
+  message: { id: string; message: Record<string, string> };
+}
+
+interface StreamState {
+  messages: Array<{ id: string; message: Record<string, string> }>;
+  groups: Map<string, { lastIndex: number }>;
+  pending: Map<string, PendingInfo>;
+  nextId: number;
+}
+
+class FakeRedis {
+  streams = new Map<string, StreamState>();
+  hashes = new Map<string, Record<string, string>>();
+
+  async xAdd(stream: string, _id: string, message: Record<string, string>) {
+    const s = this.streams.get(stream) ?? {
+      messages: [] as Array<{ id: string; message: Record<string, string> }>,
+      groups: new Map<string, { lastIndex: number }>(),
+      pending: new Map<string, PendingInfo>(),
+      nextId: 1,
+    };
+    const msgId = `${s.nextId}-0`;
+    s.nextId++;
+    const msg = { id: msgId, message };
+    s.messages.push(msg);
+    this.streams.set(stream, s);
+    return msgId;
+  }
+
+  async xGroupCreate(stream: string, group: string) {
+    const s = this.streams.get(stream) ?? {
+      messages: [] as Array<{ id: string; message: Record<string, string> }>,
+      groups: new Map<string, { lastIndex: number }>(),
+      pending: new Map<string, PendingInfo>(),
+      nextId: 1,
+    };
+    if (s.groups.has(group)) throw new Error("BUSYGROUP");
+    s.groups.set(group, { lastIndex: 0 });
+    this.streams.set(stream, s);
+  }
+
+  async xReadGroup(_group: string, consumer: string, keys: Array<{ key: string }>) {
+    const key = keys[0].key;
+    const s = this.streams.get(key);
+    if (!s) return null;
+    const g = s.groups.get("dispatcher");
+    if (!g) return null;
+    if (g.lastIndex >= s.messages.length) return null;
+    const msg = s.messages[g.lastIndex];
+    g.lastIndex++;
+    s.pending.set(msg.id, { consumer, timestamp: Date.now(), message: msg });
+    return [{ name: key, messages: [msg] }];
+  }
+
+  async xAutoClaim(stream: string, _group: string, consumer: string, minIdle: number) {
+    const s = this.streams.get(stream);
+    if (!s) return ["0-0", []] as const;
+    const now = Date.now();
+    const claimed: Array<{ id: string; message: Record<string, string> }> = [];
+    for (const [id, info] of s.pending) {
+      if (now - info.timestamp >= minIdle) {
+        info.consumer = consumer;
+        info.timestamp = now;
+        claimed.push({ id, message: info.message.message });
+      }
+    }
+    return ["0-0", claimed] as const;
+  }
+
+  async xAck(stream: string, _group: string, id: string) {
+    const s = this.streams.get(stream);
+    if (!s) return 0;
+    return s.pending.delete(id) ? 1 : 0;
+  }
+
+  async hSet(key: string, obj: Record<string, string>) {
+    const h = this.hashes.get(key) ?? {};
+    Object.assign(h, obj);
+    this.hashes.set(key, h);
+    return 1;
+  }
+}
+
+describe("dispatcher", () => {
+  let redis: FakeRedis;
+  let dispatcher: Dispatcher;
+
+  beforeEach(async () => {
+    redis = new FakeRedis();
+    dispatcher = new Dispatcher(redis, { retryMs: 0, pollMs: 0 });
+    await dispatcher.init();
+    vi.resetAllMocks();
+  });
+
+  it("envio bem-sucedido (ack)", async () => {
+    const id = await redis.xAdd("omni.outbox", "*", {
+      payload: JSON.stringify({ to: { kind: "whatsapp", contact: "123" }, text: "oi" }),
+    });
+    const spy = vi.spyOn(whatsapp, "sendWhatsappMCP").mockResolvedValue({ status: "sent" });
+    await dispatcher.runOnce();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(redis.hashes.get(`status:${id}`)).toEqual({ status: "sent" });
+    expect(redis.streams.get("omni.outbox").pending.size).toBe(0);
+  });
+
+  it("falha de MCP → nack + retry", async () => {
+    const id = await redis.xAdd("omni.outbox", "*", {
+      payload: JSON.stringify({ to: { kind: "whatsapp", contact: "123" }, text: "oi" }),
+    });
+    const spy = vi
+      .spyOn(whatsapp, "sendWhatsappMCP")
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce({ status: "sent" });
+    await dispatcher.runOnce();
+    expect(redis.hashes.get(`status:${id}`)).toEqual({ status: "failed" });
+    expect(redis.streams.get("omni.outbox").pending.size).toBe(1);
+    await dispatcher.runOnce();
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(redis.hashes.get(`status:${id}`)).toEqual({ status: "sent" });
+    expect(redis.streams.get("omni.outbox").pending.size).toBe(0);
+  });
+
+  it("mensagem malformada → dead-letter", async () => {
+    await redis.xAdd("omni.outbox", "*", { payload: "{" });
+    const spy = vi.spyOn(whatsapp, "sendWhatsappMCP");
+    await dispatcher.runOnce();
+    expect(spy).not.toHaveBeenCalled();
+    expect(redis.streams.get("omni.outbox").pending.size).toBe(0);
+    expect(redis.streams.get("omni.dlq").messages.length).toBe(1);
+  });
+});

--- a/workers/dispatcher.ts
+++ b/workers/dispatcher.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from "node:crypto";
+import { dispatch, type OutboxMessage } from "../lib/omni/dispatch";
+
+interface RedisLike {
+  xGroupCreate: (
+    stream: string,
+    group: string,
+    id: string,
+    opts: unknown,
+  ) => Promise<unknown>;
+  xReadGroup: (
+    group: string,
+    consumer: string,
+    keys: Array<{ key: string; id: string }>,
+    opts: unknown,
+  ) => Promise<
+    | null
+    | Array<{ name: string; messages: Array<{ id: string; message: Record<string, string> }> }>
+  >;
+  xAutoClaim: (
+    stream: string,
+    group: string,
+    consumer: string,
+    minIdle: number,
+    start: string,
+  ) => Promise<[string, Array<{ id: string; message: Record<string, string> }>] >;
+  xAck: (stream: string, group: string, id: string) => Promise<unknown>;
+  xAdd: (stream: string, id: string, message: Record<string, string>) => Promise<unknown>;
+  hSet: (key: string, obj: Record<string, string>) => Promise<unknown>;
+}
+
+export interface DispatcherOpts {
+  stream?: string;
+  group?: string;
+  consumer?: string;
+  dlqStream?: string;
+  pollMs?: number;
+  retryMs?: number;
+}
+
+export class Dispatcher {
+  private stream: string;
+  private group: string;
+  private consumer: string;
+  private dlq: string;
+  private pollMs: number;
+  private retryMs: number;
+
+  constructor(private client: RedisLike, opts: DispatcherOpts = {}) {
+    this.stream = opts.stream ?? "omni.outbox";
+    this.group = opts.group ?? "dispatcher";
+    this.consumer = opts.consumer ?? `disp-${randomUUID()}`;
+    this.dlq = opts.dlqStream ?? process.env.OMNI_DLQ_STREAM ?? "omni.dlq";
+    this.pollMs = opts.pollMs ?? Number(process.env.OMNI_DISPATCH_POLL_MS ?? 250);
+    this.retryMs = opts.retryMs ?? 5000;
+  }
+
+  async init() {
+    try {
+      await this.client.xGroupCreate(this.stream, this.group, "0", { MKSTREAM: true });
+      // biome-ignore lint/suspicious/noExplicitAny: redis client error type
+    } catch (err: any) {
+      if (!err?.message?.includes("BUSYGROUP")) throw err;
+    }
+  }
+
+  private async processMessage(msg: { id: string; message: Record<string, string> }) {
+    const fields = msg.message;
+    let payload: unknown;
+    try {
+      payload = JSON.parse(fields.payload);
+    } catch (err) {
+      await this.client.xAdd(this.dlq, "*", fields);
+      await this.client.xAck(this.stream, this.group, msg.id);
+      await this.client.hSet(`status:${msg.id}`, { status: "failed" });
+      console.error("malformed", err);
+      return;
+    }
+
+    try {
+      await dispatch(payload as OutboxMessage);
+      await this.client.xAck(this.stream, this.group, msg.id);
+      await this.client.hSet(`status:${msg.id}`, { status: "sent" });
+      console.log("sent", msg.id);
+    } catch (err) {
+      await this.client.hSet(`status:${msg.id}`, { status: "failed" });
+      console.error("dispatch_error", err);
+    }
+  }
+
+  async runOnce() {
+    const [, claimed] = await this.client.xAutoClaim(
+      this.stream,
+      this.group,
+      this.consumer,
+      this.retryMs,
+      "0-0",
+    );
+    for (const msg of claimed) await this.processMessage(msg);
+
+    const res = await this.client.xReadGroup(this.group, this.consumer, [{ key: this.stream, id: ">" }], { COUNT: 1, BLOCK: this.pollMs });
+    if (!res) return;
+    for (const stream of res) {
+      for (const msg of stream.messages) {
+        await this.processMessage(msg);
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add WhatsApp MCP sender
- route outbox messages to adapter
- worker consumes `omni.outbox` and persists status with retry & DLQ

## Testing
- `npx vitest run workers/dispatcher.test.ts`
- `npx biome lint adapters/whatsapp/sender.ts lib/omni/dispatch.ts workers/dispatcher.ts workers/dispatcher.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c11e8c4c8c83329a33b3b7602ec2c9