### PR TITLE
feat(agents): triage + minimal sales handler

### DIFF
--- a/agents/kb/kb_search.ts
+++ b/agents/kb/kb_search.ts
@@ -1,0 +1,12 @@
+export interface KbSnippet {
+  snippet: string;
+}
+
+/**
+ * Simple knowledge base search stub returning canned snippets.
+ */
+export async function kb_search(query: string): Promise<KbSnippet[]> {
+  return [
+    { snippet: `Informação sobre: ${query}` },
+  ];
+}

--- a/agents/router/handlers/sales.ts
+++ b/agents/router/handlers/sales.ts
@@ -1,0 +1,6 @@
+/**
+ * Minimal sales handler asking for required data to provide a quote.
+ */
+export function handleSales(): string {
+  return 'Para montar seu orçamento, preciso do consumo mensal em kWh, CEP de instalação, número de fases e telefone de contato.';
+}

--- a/agents/router/policies.ts
+++ b/agents/router/policies.ts
@@ -1,0 +1,13 @@
+export type Intent = 'greeting' | 'budget' | 'status' | 'human' | 'unknown';
+
+/**
+ * Basic regex policies to detect intent from user text.
+ */
+export function detect_intent(text: string): Intent {
+  const t = text.toLowerCase();
+  if (/(oi|olá|ola|bom dia|boa tarde|boa noite|hey)/.test(t)) return 'greeting';
+  if (/(orçamento|orcamento|preço|preco|cotação|cotacao|quanto custa|budget)/.test(t)) return 'budget';
+  if (/(status|andamento|progresso|acompanhamento|acompanho|como está|como esta)/.test(t)) return 'status';
+  if (/(humano|atendente|pessoa real|falar com (humano|atendente))/.test(t)) return 'human';
+  return 'unknown';
+}

--- a/agents/router/triage.test.ts
+++ b/agents/router/triage.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../tools/send_message', () => ({ send_message: vi.fn() }));
+vi.mock('../kb/kb_search', () => ({ kb_search: vi.fn(async () => []) }));
+
+import { triage } from './triage';
+import { send_message } from '../tools/send_message';
+import { kb_search } from '../kb/kb_search';
+
+describe('triage router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('responds to greeting', async () => {
+    await triage({ text: 'Oi', channel: 'whatsapp' });
+    expect(send_message).toHaveBeenCalledWith({
+      channel: 'whatsapp',
+      text: expect.stringMatching(/olá/i),
+    });
+  });
+
+  it('asks for sales data on budget intent', async () => {
+    await triage({ text: 'Quero um orçamento', channel: 'web' });
+    const sent = (send_message as any).mock.calls[0][0];
+    expect(sent.text).toMatch(/consumo.*kwh/i);
+    expect(sent.text).toMatch(/cep/i);
+    expect(sent.text).toMatch(/fase/i);
+    expect(sent.text).toMatch(/telefone/i);
+  });
+
+  it('includes kb snippet when available', async () => {
+    (kb_search as any).mockResolvedValue([{ snippet: 'garantia de 10 anos' }]);
+    await triage({ text: 'Qual a garantia?', channel: 'chat' });
+    const sent = (send_message as any).mock.calls[0][0];
+    expect(sent.text).toMatch(/garantia de 10 anos/);
+  });
+});

--- a/agents/router/triage.ts
+++ b/agents/router/triage.ts
@@ -1,0 +1,37 @@
+import { detect_intent, type Intent } from './policies';
+import { handleSales } from './handlers/sales';
+import { kb_search } from '../kb/kb_search';
+import { send_message } from '../tools/send_message';
+
+export interface MessageCanonical {
+  text: string;
+  channel: string;
+}
+
+export interface TriageResult {
+  intent: Intent;
+  reply: string;
+}
+
+/**
+ * Minimal triage router. Detects intent, uses handlers and tools.
+ */
+export async function triage(msg: MessageCanonical): Promise<TriageResult> {
+  const intent = detect_intent(msg.text);
+  let reply: string;
+
+  switch (intent) {
+    case 'greeting':
+      reply = 'Olá! Como posso ajudar?';
+      break;
+    case 'budget':
+      reply = handleSales();
+      break;
+    default:
+      const snippets = await kb_search(msg.text);
+      reply = snippets[0]?.snippet ?? 'Não encontrei informação relevante.';
+  }
+
+  await send_message({ channel: msg.channel, text: reply });
+  return { intent, reply };
+}

--- a/agents/tools/send_message.ts
+++ b/agents/tools/send_message.ts
@@ -1,0 +1,13 @@
+export interface OutboundMessage {
+  channel: string;
+  text: string;
+}
+
+/**
+ * Minimal send_message tool stub.
+ * In real system this would publish to omni.outbox.
+ */
+export async function send_message(msg: OutboundMessage): Promise<OutboundMessage> {
+  // Simulate async delivery
+  return msg;
+}


### PR DESCRIPTION
## Summary
- implement intent policies and triage router
- add minimal sales handler and kb search stub
- cover triage flow with vitest

## Testing
- `npx vitest run agents/router/triage.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c11edc053c8332a4b05aa9658b9387