### PR TITLE
feat(agents): triage + minimal sales

### DIFF
--- a/agents/kb/kb_search.ts
+++ b/agents/kb/kb_search.ts
@@ -1,0 +1,8 @@
+/**
+ * Stub knowledge base search.
+ * Returns a simple snippet referencing the query.
+ */
+export async function kb_search(query: string): Promise<string[]> {
+  if (!query) return [];
+  return [`Snippet sobre: ${query}`];
+}

--- a/agents/router/handlers/sales.ts
+++ b/agents/router/handlers/sales.ts
@@ -1,0 +1,6 @@
+/**
+ * Minimal sales handler asking for required information.
+ */
+export function handleSales(): string {
+  return 'Para montar seu orçamento preciso do consumo em kWh, CEP, tipo de fase e telefone de contato.';
+}

--- a/agents/router/policies.ts
+++ b/agents/router/policies.ts
@@ -1,0 +1,26 @@
+export type Intent = 'greeting' | 'budget' | 'status' | 'human' | 'unknown';
+
+/**
+ * Classifies a text message into an intent using simple regex rules.
+ */
+export function classify(text: string): Intent {
+  const msg = text.toLowerCase();
+
+  if (/^\s*(ol[áa]|oi|bom dia|boa tarde|boa noite)/.test(msg)) {
+    return 'greeting';
+  }
+
+  if (/orç[aã]mento|preço|quanto custa|cotação|budget/.test(msg)) {
+    return 'budget';
+  }
+
+  if (/status|andamento|como est[aá]|progresso/.test(msg)) {
+    return 'status';
+  }
+
+  if (/humano|atendente|pessoa/.test(msg)) {
+    return 'human';
+  }
+
+  return 'unknown';
+}

--- a/agents/router/triage.test.ts
+++ b/agents/router/triage.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { triage } from './triage';
+import * as sendModule from '../send_message';
+
+vi.mock('../send_message', () => ({
+  send_message: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('triage router', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('responds to greeting', async () => {
+    const res = await triage({ text: 'Oi', channel: 'whatsapp', from: 'user' });
+    expect(res.intent).toBe('greeting');
+    expect(res.reply).toMatch(/ol[áa]/i);
+    expect(sendModule.send_message).toHaveBeenCalledWith({
+      channel: 'whatsapp',
+      to: 'user',
+      text: res.reply,
+    });
+  });
+
+  it('handles budget intent with checklist', async () => {
+    const res = await triage({ text: 'Quero um orçamento', channel: 'whatsapp' });
+    expect(res.intent).toBe('budget');
+    expect(res.reply).toMatch(/consumo.*kwh/i);
+    expect(res.reply).toMatch(/CEP/i);
+    expect(res.reply).toMatch(/fase/i);
+    expect(res.reply).toMatch(/telefone/i);
+  });
+
+  it('includes kb snippet in reply', async () => {
+    const res = await triage({ text: 'informação solar', channel: 'whatsapp' });
+    expect(res.snippets.length).toBeGreaterThan(0);
+    expect(res.reply).toContain(res.snippets[0]);
+  });
+});

--- a/agents/router/triage.ts
+++ b/agents/router/triage.ts
@@ -1,0 +1,55 @@
+import { classify, type Intent } from './policies';
+import { handleSales } from './handlers/sales';
+import { kb_search } from '../kb/kb_search';
+import { send_message, type OutgoingMessage } from '../send_message';
+
+export interface MessageCanonical {
+  text: string;
+  channel: string;
+  from?: string;
+}
+
+export interface TriageResult {
+  intent: Intent;
+  reply: string;
+  snippets: string[];
+}
+
+/**
+ * Main triage router: classifies intent, searches KB and sends reply.
+ */
+export async function triage(msg: MessageCanonical): Promise<TriageResult> {
+  const intent = classify(msg.text);
+  const snippets = await kb_search(msg.text);
+
+  let reply: string;
+  switch (intent) {
+    case 'greeting':
+      reply = 'Olá! Como posso ajudar?';
+      break;
+    case 'budget':
+      reply = handleSales();
+      break;
+    case 'status':
+      reply = 'Estamos verificando seu pedido. Em breve retornaremos.';
+      break;
+    case 'human':
+      reply = 'Claro, vou encaminhar para um atendente humano.';
+      break;
+    default:
+      reply = 'Desculpe, não entendi.';
+  }
+
+  if (snippets.length) {
+    reply += `\n\n${snippets[0]}`;
+  }
+
+  const outbound: OutgoingMessage = {
+    channel: msg.channel,
+    to: msg.from,
+    text: reply,
+  };
+  await send_message(outbound);
+
+  return { intent, reply, snippets };
+}

--- a/agents/send_message.ts
+++ b/agents/send_message.ts
@@ -1,0 +1,13 @@
+export interface OutgoingMessage {
+  channel: string;
+  to?: string;
+  text: string;
+}
+
+/**
+ * Stub send_message tool.
+ * In a real system this would publish to omni.outbox.
+ */
+export async function send_message(_msg: OutgoingMessage): Promise<void> {
+  // no-op stub
+}


### PR DESCRIPTION
## Summary
- add simple intent policies and triage router that sends replies
- implement minimal sales handler and knowledge base search stub
- cover triage with unit tests

## Testing
- `npx vitest run agents/router/triage.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c11ef9569883329aa8180ca167cf19