### PR TITLE
feat(chat): responses integrated to omni inbox

### DIFF
--- a/app/(chat)/responses/hooks/useChat.ts
+++ b/app/(chat)/responses/hooks/useChat.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useState } from 'react';
+import { nanoid } from 'nanoid';
+
+import { addMessage, getMessages, setMessages, type StoredMessage } from '../../../../lib/store/messages';
+import { fetchOutbox, postInbox } from '../../../../lib/omni/client';
+
+export interface UseChatOptions {
+  threadId: string;
+  pollInterval?: number;
+}
+
+export function useChat({ threadId, pollInterval = 1000 }: UseChatOptions) {
+  const [messages, setLocal] = useState<StoredMessage[]>(() => getMessages(threadId));
+  const [error, setError] = useState<string | null>(null);
+
+  const sendMessage = useCallback(async (content: string) => {
+    const message: StoredMessage = { id: nanoid(), role: 'user', content };
+    addMessage(threadId, message);
+    setLocal([...messages, message]);
+    try {
+      await postInbox({ threadId, content });
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }, [messages, threadId]);
+
+  useEffect(() => {
+    const id = setInterval(async () => {
+      try {
+        const out = await fetchOutbox(threadId);
+        if (out.length) {
+          const current = getMessages(threadId);
+          const newMsgs = out.map(m => ({ id: m.id, role: 'assistant', content: m.content }));
+          const all = [...current, ...newMsgs];
+          setMessages(threadId, all);
+          setLocal(all);
+        }
+      } catch (err) {
+        // ignore polling errors
+      }
+    }, pollInterval);
+    return () => clearInterval(id);
+  }, [threadId, pollInterval]);
+
+  return { messages, sendMessage, error };
+}

--- a/app/(chat)/responses/page.tsx
+++ b/app/(chat)/responses/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React, { FormEvent, useState } from 'react';
+import { useChat } from './hooks/useChat';
+import '../../../styles/chat.css';
+
+export default function ResponsesPage() {
+  const threadId = 'default';
+  const { messages, sendMessage, error } = useChat({ threadId });
+  const [input, setInput] = useState('');
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    await sendMessage(input.trim());
+    setInput('');
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="chat-messages">
+        {messages.map(m => (
+          <div key={m.id} className={`chat-message chat-${m.role}`}>
+            {m.content}
+          </div>
+        ))}
+      </div>
+      {error && <div className="chat-error">{error}</div>}
+      <form onSubmit={onSubmit} className="chat-composer">
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          className="chat-input"
+          placeholder="Digite uma mensagem"
+        />
+        <button type="submit" className="chat-send">Enviar</button>
+      </form>
+    </div>
+  );
+}

--- a/lib/omni/client.ts
+++ b/lib/omni/client.ts
@@ -1,0 +1,35 @@
+export interface InboxMessage {
+  threadId: string;
+  content: string;
+}
+
+export interface OutboxMessage {
+  id: string;
+  threadId: string;
+  content: string;
+}
+
+/**
+ * Post a message to the omni inbox.
+ */
+export async function postInbox(message: InboxMessage): Promise<void> {
+  const res = await fetch('/api/omni/inbox', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(message),
+  });
+  if (!res.ok) {
+    throw new Error('Failed to send message');
+  }
+}
+
+/**
+ * Retrieve messages from the omni outbox for a given thread.
+ */
+export async function fetchOutbox(threadId: string): Promise<OutboxMessage[]> {
+  const res = await fetch(`/api/omni/outbox?threadId=${encodeURIComponent(threadId)}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch outbox');
+  }
+  return res.json();
+}

--- a/lib/store/messages.ts
+++ b/lib/store/messages.ts
@@ -1,0 +1,37 @@
+export interface StoredMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const PREFIX = 'responses:';
+const cache = new Map<string, StoredMessage[]>();
+
+function storageKey(threadId: string) {
+  return `${PREFIX}${threadId}`;
+}
+
+export function getMessages(threadId: string): StoredMessage[] {
+  if (cache.has(threadId)) return cache.get(threadId)!;
+  if (typeof window === 'undefined') return [];
+  const raw = localStorage.getItem(storageKey(threadId));
+  const msgs: StoredMessage[] = raw ? JSON.parse(raw) : [];
+  cache.set(threadId, msgs);
+  return msgs;
+}
+
+export function setMessages(threadId: string, messages: StoredMessage[]) {
+  cache.set(threadId, messages);
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(storageKey(threadId), JSON.stringify(messages));
+}
+
+export function addMessage(threadId: string, message: StoredMessage) {
+  const messages = getMessages(threadId);
+  messages.push(message);
+  setMessages(threadId, messages);
+}
+
+export function clearCache() {
+  cache.clear();
+}

--- a/styles/chat.css
+++ b/styles/chat.css
@@ -1,0 +1,46 @@
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.chat-message {
+  margin-bottom: 0.5rem;
+}
+
+.chat-user {
+  text-align: right;
+}
+
+.chat-assistant {
+  text-align: left;
+}
+
+.chat-composer {
+  display: flex;
+  border-top: 1px solid #e5e7eb;
+  padding: 0.5rem;
+}
+
+.chat-input {
+  flex: 1;
+  margin-right: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 4px;
+}
+
+.chat-send {
+  padding: 0.25rem 0.75rem;
+}
+
+.chat-error {
+  color: red;
+  padding: 0.5rem;
+}

--- a/tests/responses.test.tsx
+++ b/tests/responses.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, renderHook, act } from '@testing-library/react';
+import ResponsesPage from '../app/(chat)/responses/page';
+import { useChat } from '../app/(chat)/responses/hooks/useChat';
+import { clearCache } from '../lib/store/messages';
+
+beforeEach(() => {
+  const store: Record<string, string> = {};
+  vi.stubGlobal('localStorage', {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { Object.keys(store).forEach(k => delete store[k]); },
+  });
+  clearCache();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Responses page', () => {
+  it('renders basic layout', () => {
+    render(<ResponsesPage />);
+    expect(screen.getByPlaceholderText('Digite uma mensagem')).not.toBeNull();
+  });
+});
+
+describe('useChat', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('sends message successfully', async () => {
+    (fetch as any).mockResolvedValue({ ok: true, json: async () => [] });
+    const { result } = renderHook(() => useChat({ threadId: 't1', pollInterval: 0 }));
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+    expect(result.current.messages[0].content).toBe('hello');
+    expect(localStorage.getItem('responses:t1')).not.toBeNull();
+  });
+
+  it('handles send error', async () => {
+    (fetch as any).mockResolvedValue({ ok: false });
+    const { result } = renderHook(() => useChat({ threadId: 't1', pollInterval: 0 }));
+    await act(async () => {
+      await result.current.sendMessage('hello');
+    });
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it('restores persisted history', () => {
+    localStorage.setItem('responses:t1', JSON.stringify([{ id: '1', role: 'user', content: 'stored' }]));
+    const { result } = renderHook(() => useChat({ threadId: 't1', pollInterval: 0 }));
+    expect(result.current.messages[0].content).toBe('stored');
+  });
+});


### PR DESCRIPTION
## Summary
- wire Responses chat to Omni inbox/outbox APIs
- persist chat history per thread with local cache
- add basic UI and integration tests

## Testing
- `pnpm lint`
- `npx vitest tests/responses.test.tsx --run`


------
https://chatgpt.com/codex/tasks/task_e_68c11f2a03a08332994d4a36aeb898b8