### PR TITLE
docs(env): add env example and guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,27 @@
+#### Core runtime
+NODE_ENV=development
+LOG_LEVEL=info
+WEB_BASE_URL=http://localhost:3000
+COMMIT_SHA=dev
+TELEMETRY_TRACE=on
+
+#### Omni queue
+OMNI_STREAM_MESSAGES=omni.messages
+OMNI_STREAM_OUTBOX=omni.outbox
+OMNI_GROUP=omni-core
+OMNI_BLOCK_MS=5000
+OMNI_DISPATCH_POLL_MS=250
+OMNI_DLQ_STREAM=omni.dlq
+
+#### WhatsApp MCP
+MCP_WHATSAPP_URL=ws://localhost:8080
+MCP_TOKEN=changeme
+
+#### Secrets
 # Generate a random secret: https://generate-secret.vercel.app/32 or `openssl rand -base64 32`
 AUTH_SECRET=your-random-secret-here
 
-# For local Docker setup (FOSS alternatives)
+#### Persistence
 # PostgreSQL (local via Docker)
 POSTGRES_URL=postgresql://user:password@localhost:5432/ai_ysh
 
@@ -11,6 +31,7 @@ REDIS_URL=redis://localhost:6379
 # MinIO for blob storage (S3-compatible, local via Docker)
 BLOB_READ_WRITE_TOKEN=minioadmin:minioadmin@localhost:9000/ai-ysh
 
+#### AI Providers
 # For AI, use Ollama (local models)
 # Set to 'local' or your Ollama endpoint
 AI_GATEWAY_API_KEY=local

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Toda a documentação do projeto está organizada na pasta [`docs/`](./docs/):
 - [Load Balancing](./docs/LOAD_BALANCING_README.md) - Sistema de balanceamento de carga
 - [Personas Blueprint](./docs/PERSONAS_BLUEPRINT.md) - Sistema de personas do usuário
 - [UI Components](./docs/UI_COMPONENTS_MAPPING.md) - Mapeamento de componentes
+- [Environment Variables](./docs/env.md) - Configuração de variáveis de ambiente
 
 ## Estrutura do Projeto
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,39 @@
+# Environment Variables
+
+The application relies on environment variables for configuration. Copy the [`.env.example`](../.env.example) file to `.env` and adjust the values for your environment.
+
+## Setup
+
+1. `cp .env.example .env`
+2. Fill in the values marked as `changeme` or placeholders.
+3. **Never commit the `.env` file**. Keep secrets out of version control.
+
+## Variables
+
+| Variable | Description | Example |
+| --- | --- | --- |
+| `NODE_ENV` | Node.js runtime environment | `development` |
+| `LOG_LEVEL` | Logging verbosity level | `info` |
+| `REDIS_URL` | Connection string for Redis broker | `redis://localhost:6379` |
+| `OMNI_STREAM_MESSAGES` | Stream name for incoming messages | `omni.messages` |
+| `OMNI_STREAM_OUTBOX` | Stream name for outgoing messages | `omni.outbox` |
+| `OMNI_GROUP` | Consumer group used by Omni workers | `omni-core` |
+| `OMNI_BLOCK_MS` | Block timeout when reading streams (ms) | `5000` |
+| `OMNI_DISPATCH_POLL_MS` | Poll interval for dispatching messages (ms) | `250` |
+| `OMNI_DLQ_STREAM` | Dead letter queue stream name | `omni.dlq` |
+| `MCP_WHATSAPP_URL` | WebSocket endpoint for WhatsApp MCP | `ws://localhost:8080` |
+| `MCP_TOKEN` | Token for authenticating with the MCP | `changeme` |
+| `WEB_BASE_URL` | Base URL for the web application | `http://localhost:3000` |
+| `COMMIT_SHA` | Commit identifier used in logs and telemetry | `dev` |
+| `TELEMETRY_TRACE` | Enables tracing when set to `on` | `on` |
+| `AUTH_SECRET` | Secret used by Auth.js for session encryption | `your-random-secret-here` |
+| `POSTGRES_URL` | PostgreSQL connection string | `postgresql://user:password@localhost:5432/ai_ysh` |
+| `BLOB_READ_WRITE_TOKEN` | Token for S3-compatible blob storage | `minioadmin:minioadmin@localhost:9000/ai-ysh` |
+| `AI_GATEWAY_API_KEY` | API key for the AI Gateway or `local` for Ollama | `local` |
+| `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` | Google Maps API key for map features | `your-google-maps-key` |
+
+## Security Notes
+
+- Rotate tokens and secrets regularly.
+- Use separate credentials for development and production.
+- When deploying, store variables in your platform's secret manager (e.g., Vercel, Docker secrets).


### PR DESCRIPTION
## Summary
- add complete `.env.example` for local boot
- document environment variables in `docs/env.md`
- link env docs from main README

## Testing
- `pnpm exec biome lint README.md docs/env.md .env.example --no-errors-on-unmatched`
- `pnpm test` *(fails: Vitest cannot be imported in a CommonJS module)*

------
https://chatgpt.com/codex/tasks/task_e_68c11f67b5f083328f5bb713bd2ec691