### PR TITLE
feat: add Pix Parcelado messaging assets

### DIFF
--- a/apps/web/app/(chat)/api/chat/[id]/stream/route.ts
+++ b/apps/web/app/(chat)/api/chat/[id]/stream/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from 'next/server';
+import OpenAI from 'openai';
+import { track } from '@/apps/web/lib/analytics/events.pix';
+
+export const runtime = 'edge';
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const messages = await req.json();
+
+  track({
+    name: 'pix_activation_start',
+    payload: { user_id: params.id, channel: 'web' },
+  });
+
+  const response = await client.responses.create({
+    model: 'gpt-4o-mini',
+    stream: true,
+    messages,
+    tools: [
+      {
+        type: 'function',
+        name: 'track',
+        description: 'Envio de eventos de analytics',
+        parameters: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            payload: { type: 'object' },
+          },
+          required: ['name', 'payload'],
+        },
+      },
+    ],
+  });
+
+  return response.toStreamResponse({
+    onEvent(event) {
+      if (event.type === 'tool' && event.name === 'track') {
+        track(event.arguments as any);
+      }
+    },
+  });
+}

--- a/apps/web/lib/analytics/events.pix.ts
+++ b/apps/web/lib/analytics/events.pix.ts
@@ -1,0 +1,16 @@
+export type PixEvents =
+  | { name: 'ux.copy_click'; payload: { component_id: string } }
+  | { name: 'pix_activation_start'; payload: { user_id: string; channel: 'app' | 'web' | 'whatsapp' } }
+  | { name: 'pix_activation_success'; payload: { user_id: string; value: number } }
+  | { name: 'ux.form_error'; payload: { field: string; error_type: string } }
+  | { name: 'pix_simulation_done'; payload: { amount: number; installments: number } }
+  | { name: 'cta_activate_click'; payload: { channel: 'app' | 'web' | 'whatsapp' | 'push' } }
+  | { name: 'whatsapp_template_sent'; payload: { template_name: string; user_id: string } };
+
+export function track<E extends PixEvents>(event: E) {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('analytics', { detail: event }));
+  }
+  // server-side: log/queue
+  // console.log('[analytics]', event);
+}

--- a/apps/web/lib/cadence/pixParcelado.ts
+++ b/apps/web/lib/cadence/pixParcelado.ts
@@ -1,0 +1,101 @@
+export type Channel = 'app' | 'web' | 'whatsapp' | 'push' | 'email' | 'chat';
+export interface Step {
+  stage:
+    | 'descoberta'
+    | 'onboarding'
+    | 'ativacao'
+    | 'conversao'
+    | 'retencao'
+    | 'reengajamento'
+    | 'suporte';
+  objective: string;
+  trigger: string;
+  channel: Channel;
+  timing: string; // ex.: 'imediato' | '+5min' | 'D+1 09:00'
+  short: string;
+  long: string;
+  cta: string;
+  kpi: string;
+}
+
+export const pixParceladoCadence: Step[] = [
+  {
+    stage: 'descoberta',
+    objective: 'apresentar o Pix Parcelado',
+    trigger: 'visita tela de pagamentos',
+    channel: 'app',
+    timing: 'imediato',
+    short: 'Parcelar Pix? T\u00e1 na m\u00e3o. \uD83D\uDCA5',
+    long: 'Quer dividir seu Pix em at\u00e9 12x sem drama? Aqui rola. S\u00f3 ativar o Pix Parcelado.',
+    cta: 'Conferir detalhes',
+    kpi: 'banner_clicks',
+  },
+  {
+    stage: 'onboarding',
+    objective: 'explicar como funciona',
+    trigger: 'in\u00edcio de cadastro',
+    channel: 'web',
+    timing: 'durante cadastro',
+    short: '\u00c9 rapidinho, juro.',
+    long: 'Preenche seus dados, mostra que \u00e9 voc\u00ea e pronto: cr\u00e9dito liberado pra parcelar Pix.',
+    cta: 'Bora continuar',
+    kpi: 'signup_completion',
+  },
+  {
+    stage: 'ativacao',
+    objective: 'finalizar contrato',
+    trigger: 'cadastro aprovado',
+    channel: 'whatsapp',
+    timing: '+5min',
+    short: 'Pix Parcelado pronto pra a\u00e7\u00e3o. \u26A1\uFE0F',
+    long: 'Seu limite j\u00e1 t\u00e1 na conta. Assina o termo rapid\u00e3o e come\u00e7a a usar.',
+    cta: 'Ativar agora',
+    kpi: 'activation_rate',
+  },
+  {
+    stage: 'conversao',
+    objective: 'primeira opera\u00e7\u00e3o',
+    trigger: '24h sem uso',
+    channel: 'push',
+    timing: 'D+1',
+    short: 'Vai deixar o Pix Parcelado parado?',
+    long: 'Primeira compra com Pix Parcelado tem zero tarifa. Aproveita e testa.',
+    cta: 'Fechar pedido',
+    kpi: 'first_tx_rate',
+  },
+  {
+    stage: 'retencao',
+    objective: 'uso recorrente',
+    trigger: 'ciclo de fatura',
+    channel: 'email',
+    timing: '-3 dias vencimento',
+    short: 'Fatura chegando, tudo sob controle.',
+    long: 'Sua fatura do Pix Parcelado vence em 3 dias. Paga em dia, evita juros extras e libera limite pra pr\u00f3xima.',
+    cta: 'Pagar agora',
+    kpi: 'delinquency_rate',
+  },
+  {
+    stage: 'reengajamento',
+    objective: 'recuperar inativos',
+    trigger: '30 dias sem uso',
+    channel: 'whatsapp',
+    timing: '+30d',
+    short: 'Saudade do seu Pix Parcelado.',
+    long: 'T\u00e1 sumido. Lembra que d\u00e1 pra parcelar qualquer boleto ou transfer\u00eancia. Volta pra jogada.',
+    cta: 'Ativar agora',
+    kpi: 'reactivation_rate',
+  },
+  {
+    stage: 'suporte',
+    objective: 'resolver d\u00favidas/erros',
+    trigger: 'erro 500 ou ticket',
+    channel: 'chat',
+    timing: 'imediato',
+    short: 'Deu ruim? A gente resolve.',
+    long: 'Rolou erro no Pix Parcelado? Conta o que aconteceu que j\u00e1 desatamos.',
+    cta: 'Chamar suporte',
+    kpi: 'ttr',
+  },
+];
+
+export type PixParceladoCadence = typeof pixParceladoCadence;

--- a/apps/web/lib/copy/bankoxPix.ts
+++ b/apps/web/lib/copy/bankoxPix.ts
@@ -1,0 +1,70 @@
+export const bankoxPixCopy = {
+  titles: [
+    "Pix Parcelado na área.",
+    "Divide o Pix e segue a vida.",
+    "Crédito rápido, sem novela."
+  ],
+  subtitles: [
+    "Até 12x, na hora, sem drama.",
+    "Compra agora, paga com calma.",
+    "Confere os números, depois é só usar."
+  ],
+  ctas: {
+    primary: [
+      "Bora continuar",
+      "Ativar agora",
+      "Fechar pedido",
+      "Conferir detalhes",
+      "Pagar agora",
+      "Chamar suporte"
+    ],
+    secondary: ["Ver depois", "Ajustar mais tarde", "Voltar"],
+    destructive: ["Cancelar tudo", "Remover isso", "Desistir por enquanto"]
+  },
+  placeholders: {
+    search: ["Procura aí — sem medo", "Manda o nome do contato"],
+    email: ["seunome@email.com", "nome.sobrenome@dominio.com"],
+    phone: ["(11) 9XXXX-XXXX", "(21) 9XXXX-XXXX"]
+  },
+  errors: {
+    empty: "Preenche isso aqui primeiro.",
+    invalid: "Hum… isso não parece certo. Confere o formato.",
+    network: "Caiu a conexão. Respira e tenta de novo.",
+    unauthorized: "Você não tem acesso a isso (ainda).",
+    notFound: "A gente procurou e não achou nada.",
+    server: "Deu ruim do nosso lado. Já estamos em cima.",
+    cpfInvalid: "Confere esse CPF. Tem número trocado.",
+    overLimit: "Esse valor passa do seu limite atual."
+  },
+  emptyStates: {
+    list: ["Nada por aqui… ainda.", "Tá vazio, mas logo enche."],
+    noResults: [
+      "Com esse filtro, nem o sol aparece. Tira a mão.",
+      "Zero resultados. Ajusta o filtro e tenta de novo."
+    ],
+    noPermission: [
+      "Você não tá autorizado a ver isso.",
+      "Permissão negada. Fala com o admin."
+    ]
+  },
+  toasts: {
+    success: "Tudo certo! 💥",
+    error: "Falhou agora, mas não desiste não.",
+    warn: "Quase lá. Falta um detalhe.",
+    info: (limite: string) => `Fica ligado: limite atual R$ ${limite}.`
+  },
+  tooltips: [
+    "Taxa aplicada só se parcelar. À vista, zero custo.",
+    "Limite aumenta conforme você paga em dia."
+  ],
+  a11y: {
+    altCheck: "Ícone de check verde",
+    ariaActivate: "Ativar Pix Parcelado"
+  },
+  lgpd: {
+    consent: "Usaremos seus dados para avaliar limite do Pix Parcelado.",
+    optoutWhatsapp: "Responda SAIR para parar."
+  }
+} as const;
+
+export type BankoxPixCopy = typeof bankoxPixCopy;

--- a/apps/web/lib/waba/templates.bankox.json
+++ b/apps/web/lib/waba/templates.bankox.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "pix_parcelado_approved",
+    "category": "UTILITY",
+    "language": "pt_BR",
+    "components": [
+      { "type": "HEADER", "format": "TEXT", "text": "Pix Parcelado liberado! \uD83D\uDCA5" },
+      { "type": "BODY", "text": "Renata, seu limite \u00e9 de R$ {{1}} em at\u00e9 {{2}}x. Assina o termo e parte pro abra\u00e7o.", "example": { "body_text": [["2.000,00", "12"]] } },
+      { "type": "FOOTER", "text": "BankoX — cr\u00e9dito sem novela." },
+      { "type": "BUTTONS", "buttons": [ { "type": "URL", "text": "Assinar agora", "url": "https://bankox.com/termo/{{1}}" } ] }
+    ]
+  },
+  {
+    "name": "pix_parcelado_reminder",
+    "category": "MARKETING",
+    "language": "pt_BR",
+    "components": [
+      { "type": "HEADER", "format": "TEXT", "text": "Ei, vai parcelar ou n\u00e3o?" },
+      { "type": "BODY", "text": "Fatura fecha em {{1}} dias e voc\u00ea ainda n\u00e3o usou o Pix Parcelado. Primeira opera\u00e7\u00e3o sem tarifa. Bora?", "example": { "body_text": [["3"]] } },
+      { "type": "FOOTER", "text": "Cancelou? \u00c9 s\u00f3 responder SAIR." },
+      { "type": "BUTTONS", "buttons": [ { "type": "QUICK_REPLY", "text": "Usar agora" } ] }
+    ]
+  },
+  {
+    "name": "pix_parcelado_activation_nudge",
+    "category": "UTILITY",
+    "language": "pt_BR",
+    "components": [
+      { "type": "HEADER", "format": "TEXT", "text": "Ativa e vai. \u26A1\uFE0F" },
+      { "type": "BODY", "text": "Seu cadastro foi aprovado. Assina e ativa o Pix Parcelado em 1 minuto. Limite: R$ {{1}}.", "example": { "body_text": [["1.500,00"]] } },
+      { "type": "FOOTER", "text": "D\u00favidas? Responda aqui." },
+      { "type": "BUTTONS", "buttons": [ { "type": "URL", "text": "Ativar agora", "url": "https://bankox.com/ativar/{{1}}" } ] }
+    ]
+  }
+]

--- a/apps/web/scripts/qa.pixParcelado.ts
+++ b/apps/web/scripts/qa.pixParcelado.ts
@@ -1,0 +1,30 @@
+import { bankoxPixCopy } from '../lib/copy/bankoxPix';
+import { pixParceladoCadence } from '../lib/cadence/pixParcelado';
+
+function assert(condition: boolean, msg: string) {
+  if (!condition) throw new Error(msg);
+}
+
+const allCTAs = new Set<string>([
+  ...bankoxPixCopy.ctas.primary,
+  ...bankoxPixCopy.ctas.secondary,
+  ...bankoxPixCopy.ctas.destructive,
+]);
+
+pixParceladoCadence.forEach((step) =>
+  assert(allCTAs.has(step.cta), `CTA n\u00e3o encontrado: ${step.cta}`),
+);
+
+['empty', 'invalid', 'network', 'unauthorized', 'notFound', 'server'].forEach(
+  (key) =>
+    assert(
+      !!bankoxPixCopy.errors[key as keyof typeof bankoxPixCopy.errors],
+      `Erro faltando: ${key}`,
+    ),
+);
+
+bankoxPixCopy.placeholders.phone.forEach((p) =>
+  assert(/\(\d{2}\)/.test(p), `Placeholder telefone inv\u00e1lido: ${p}`),
+);
+
+console.log('QA Pix Parcelado: \u2705 passou em todas as checagens.');


### PR DESCRIPTION
## Summary
- add microcopy library and omnichannel cadence for Pix Parcelado
- include WABA templates, analytics tracking, and streaming chat endpoint
- add QA script to validate copy and cadence consistency

## Testing
- `npx tsx apps/web/scripts/qa.pixParcelado.ts`
- `pnpm test` *(fails: Error executing tool solar_calculator, lead_analyzer; document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c18fb3dccc8332aa26f1f18e72dcd2