### PR TITLE
feat: add basic analytics events

### DIFF
--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -1,0 +1,56 @@
+import { track } from "@vercel/analytics/server";
+
+export interface AppOpenPayload {
+	device_id: string;
+	source: string;
+	timestamp: string;
+}
+
+export interface SignupCompletePayload {
+	user_id: string;
+	method: string;
+	timestamp: string;
+}
+
+export interface FeatureViewPayload {
+	user_id: string;
+	feature_id: string;
+	timestamp: string;
+}
+
+export interface ActivationSuccessPayload {
+	user_id: string;
+	feature_id: string;
+	timestamp: string;
+}
+
+export interface PurchaseConfirmedPayload {
+	user_id: string;
+	plan_type: string;
+	value: number;
+	timestamp: string;
+}
+
+export interface SupportTicketPayload {
+	user_id: string;
+	category: string;
+	resolved: boolean;
+}
+
+export type AnalyticsEventPayloads = {
+	app_open: AppOpenPayload;
+	signup_complete: SignupCompletePayload;
+	feature_view: FeatureViewPayload;
+	activation_success: ActivationSuccessPayload;
+	purchase_confirmed: PurchaseConfirmedPayload;
+	support_ticket: SupportTicketPayload;
+};
+
+export type AnalyticsEventName = keyof AnalyticsEventPayloads;
+
+export async function trackEvent<E extends AnalyticsEventName>(
+	name: E,
+	payload: AnalyticsEventPayloads[E],
+) {
+	await track(name, payload);
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,59 +1,68 @@
-import { NextResponse, type NextRequest } from 'next/server';
-import { getToken } from 'next-auth/jwt';
-import { guestRegex, isDevelopmentEnvironment } from './lib/constants';
+import { getToken } from "next-auth/jwt";
+import { type NextRequest, NextResponse } from "next/server";
+import { trackEvent } from "./lib/analytics/events";
+import { guestRegex, isDevelopmentEnvironment } from "./lib/constants";
 
 export async function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
+	const { pathname } = request.nextUrl;
 
-  /*
-   * Playwright starts the dev server and requires a 200 status to
-   * begin the tests, so this ensures that the tests can start
-   */
-  if (pathname.startsWith('/ping')) {
-    return new Response('pong', { status: 200 });
-  }
+	if (pathname === "/") {
+		void trackEvent("app_open", {
+			device_id: request.headers.get("user-agent") ?? "unknown",
+			source: request.headers.get("referer") ?? "direct",
+			timestamp: new Date().toISOString(),
+		});
+	}
 
-  if (pathname.startsWith('/api/auth')) {
-    return NextResponse.next();
-  }
+	/*
+	 * Playwright starts the dev server and requires a 200 status to
+	 * begin the tests, so this ensures that the tests can start
+	 */
+	if (pathname.startsWith("/ping")) {
+		return new Response("pong", { status: 200 });
+	}
 
-  const token = await getToken({
-    req: request,
-    secret: process.env.AUTH_SECRET,
-    secureCookie: !isDevelopmentEnvironment,
-  });
+	if (pathname.startsWith("/api/auth")) {
+		return NextResponse.next();
+	}
 
-  if (!token) {
-    const redirectUrl = encodeURIComponent(request.url);
+	const token = await getToken({
+		req: request,
+		secret: process.env.AUTH_SECRET,
+		secureCookie: !isDevelopmentEnvironment,
+	});
 
-    return NextResponse.redirect(
-      new URL(`/api/auth/guest?redirectUrl=${redirectUrl}`, request.url),
-    );
-  }
+	if (!token) {
+		const redirectUrl = encodeURIComponent(request.url);
 
-  const isGuest = guestRegex.test(token?.email ?? '');
+		return NextResponse.redirect(
+			new URL(`/api/auth/guest?redirectUrl=${redirectUrl}`, request.url),
+		);
+	}
 
-  if (token && !isGuest && ['/login', '/register'].includes(pathname)) {
-    return NextResponse.redirect(new URL('/', request.url));
-  }
+	const isGuest = guestRegex.test(token?.email ?? "");
 
-  return NextResponse.next();
+	if (token && !isGuest && ["/login", "/register"].includes(pathname)) {
+		return NextResponse.redirect(new URL("/", request.url));
+	}
+
+	return NextResponse.next();
 }
 
 export const config = {
-  matcher: [
-    '/',
-    '/chat/:id',
-    '/api/:path*',
-    '/login',
-    '/register',
+	matcher: [
+		"/",
+		"/chat/:id",
+		"/api/:path*",
+		"/login",
+		"/register",
 
-    /*
-     * Match all request paths except for the ones starting with:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico, sitemap.xml, robots.txt (metadata files)
-     */
-    '/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
-  ],
+		/*
+		 * Match all request paths except for the ones starting with:
+		 * - _next/static (static files)
+		 * - _next/image (image optimization files)
+		 * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+		 */
+		"/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+	],
 };


### PR DESCRIPTION
## Summary
- define typed analytics events and tracking helper
- log app_open when root path is requested

## Testing
- `pnpm exec biome check lib/analytics/events.ts middleware.ts`
- `pnpm test` *(fails: document is not defined, TypeError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c1924c684c83328b579864e15c738a