### PR TITLE
feat: expand analytics event tracking

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useActionState, useEffect, useState } from "react";
 import { toast } from "@/components/toast";
+import { track } from "@/apps/web/lib/analytics/events.pix";
 
 import { AuthForm } from "@/components/auth-form";
 import { SubmitButton } from "@/components/submit-button";
@@ -32,10 +33,18 @@ export default function Page() {
         type: "error",
         description: "Invalid credentials!",
       });
+      track({
+        name: "ux.form_error",
+        payload: { field: "credentials", error_type: "invalid" },
+      });
     } else if (state.status === "invalid_data") {
       toast({
         type: "error",
         description: "Failed validating your submission!",
+      });
+      track({
+        name: "ux.form_error",
+        payload: { field: "form", error_type: "validation" },
       });
     } else if (state.status === "success") {
       setIsSuccessful(true);

--- a/apps/web/app/(chat)/api/chat/[id]/stream/route.ts
+++ b/apps/web/app/(chat)/api/chat/[id]/stream/route.ts
@@ -40,6 +40,11 @@ export async function POST(
     ],
   });
 
+  track({
+    name: 'pix_activation_success',
+    payload: { user_id: params.id, value: 1 },
+  });
+
   return response.toStreamResponse({
     onEvent(event) {
       if (event.type === 'tool' && event.name === 'track') {

--- a/packages/ui-cards/ArchiveCard.tsx
+++ b/packages/ui-cards/ArchiveCard.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 import { z } from 'zod';
+import { track } from '../../apps/web/lib/analytics/events.pix';
 
 // Schema validation for archive receipt data
 export const archiveReceiptSchema = z.object({
@@ -53,6 +54,7 @@ export const ArchiveCard: React.FC<ArchiveCardProps> = (props) => {
 
   const copyChecksum = async () => {
     await navigator.clipboard.writeText(data.checksum);
+    track({ name: 'ux.copy_click', payload: { component_id: 'archive_checksum' } });
   };
 
   return (

--- a/packages/ui-viewers/STACAssetViewer.tsx
+++ b/packages/ui-viewers/STACAssetViewer.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { z } from 'zod';
+import { track } from '../../apps/web/lib/analytics/events.pix';
 
 // Schema for a STAC asset
 export const stacAssetSchema = z.object({
@@ -60,6 +61,7 @@ export const STACAssetViewer: React.FC<STACAssetViewerProps> = ({
   const copyHref = async (href: string) => {
     try {
       await navigator.clipboard.writeText(href);
+      track({ name: 'ux.copy_click', payload: { component_id: 'stac_asset_href' } });
     } catch {
       // ignore clipboard errors
     }


### PR DESCRIPTION
## Summary
- track copy actions in archive and STAC asset components
- capture form errors on login page
- log activation success in chat stream

## Testing
- `pnpm lint` (fails: 4056 errors)
- `pnpm test` (fails: multiple test failures)
- `pnpm test packages/ui-cards/ArchiveCard.test.ts packages/ui-viewers/STACAssetViewer.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68c1b8d7c9bc83328d76ff7ac3dc733f