### PR TITLE
feat(ui): add brand variants and centralize tokens

### DIFF
--- a/components.json
+++ b/components.json
@@ -6,7 +6,7 @@
   "tailwind": {
     "config": "tailwind.config.ts",
     "css": "app/globals.css",
-    "baseColor": "zinc",
+    "baseColor": "yellow",
     "cssVariables": true,
     "prefix": ""
   },

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
+import { brandGradient } from "@/lib/brand"
 
 const alertVariants = cva(
   "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
@@ -10,6 +11,8 @@ const alertVariants = cva(
         default: "bg-background text-foreground",
         destructive:
           "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        solar: `${brandGradient} text-primary-foreground border-none`,
+        eco: "border-green-600 bg-green-50 text-green-900 dark:border-green-900 dark:bg-green-900/20 dark:text-green-300",
       },
     },
     defaultVariants: {

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -3,18 +3,31 @@
 import * as React from "react"
 import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
+import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
+import { brandRing } from "@/lib/brand"
+
+const avatarVariants = cva(
+  "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
+  {
+    variants: {
+      variant: {
+        default: "",
+        solar: brandRing,
+        eco: "ring-2 ring-eco-500",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  }
+)
 
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root> & VariantProps<typeof avatarVariants>
+>(({ className, variant, ...props }, ref) => (
   <AvatarPrimitive.Root
     ref={ref}
-    className={cn(
-      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
-      className
-    )}
+    className={cn(avatarVariants({ variant }), className)}
     {...props}
   />
 ))

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -3,6 +3,7 @@ import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
+import { brandGradient } from "@/lib/brand"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -18,7 +19,7 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        solar: "bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand-accent))] text-primary-foreground hover:opacity-90 shadow-lg hover:shadow-xl transition-all duration-200",
+        solar: `${brandGradient} text-primary-foreground hover:opacity-90 shadow-lg hover:shadow-xl transition-all duration-200`,
         eco: "bg-green-600 text-white hover:bg-green-700 border border-green-500 shadow-md hover:shadow-lg transition-all duration-200",
         calculator: "bg-blue-600 text-white hover:bg-blue-700 shadow-md hover:shadow-lg transition-all duration-200",
       },

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Cross2Icon } from '@radix-ui/react-icons';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
+import { brandGradient } from '@/lib/brand';
 
 const Dialog = DialogPrimitive.Root;
 const DialogTrigger = DialogPrimitive.Trigger;
@@ -23,18 +25,29 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+const dialogContentVariants = cva(
+  'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background',
+        solar: `${brandGradient} text-primary-foreground border-none`,
+        eco: 'border-green-600 bg-green-50 text-green-900 dark:border-green-900 dark:bg-green-900/20 dark:text-green-300',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  }
+);
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & VariantProps<typeof dialogContentVariants>
+>(({ className, children, variant, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
-      className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
-        className,
-      )}
+      className={cn(dialogContentVariants({ variant }), className)}
       {...props}
     >
       {children}

--- a/lib/brand.ts
+++ b/lib/brand.ts
@@ -1,0 +1,4 @@
+export const brandGradient =
+  'bg-gradient-to-r from-[hsl(var(--brand))] to-[hsl(var(--brand-accent))]';
+
+export const brandRing = 'ring-2 ring-[hsl(var(--brand))]';

--- a/stories/ui-alert.stories.tsx
+++ b/stories/ui-alert.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import React from 'react';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+
+const meta: Meta<typeof Alert> = {
+  title: 'UI/Alert',
+  component: Alert,
+};
+export default meta;
+
+type Story = StoryObj<typeof Alert>;
+
+export const Solar: Story = {
+  render: () => (
+    <Alert variant="solar">
+      <AlertTitle>Alerta Solar</AlertTitle>
+      <AlertDescription>Energia solar em destaque.</AlertDescription>
+    </Alert>
+  ),
+};
+
+export const Eco: Story = {
+  render: () => (
+    <Alert variant="eco">
+      <AlertTitle>Alerta Eco</AlertTitle>
+      <AlertDescription>Configurações ecológicas ativas.</AlertDescription>
+    </Alert>
+  ),
+};


### PR DESCRIPTION
## Summary
- centralize brand gradient and ring utilities
- add solar and eco variants to alert, dialog, avatar and reuse in button
- showcase alert variants via new Storybook story and set default base color to yellow

## Testing
- `pnpm lint` *(fails: The number of diagnostics exceeds the number allowed by Biome. Found 4125 errors.)*
- `pnpm test` *(fails: 52 failed | 25 passed)*
- `pnpm typecheck` *(fails: apps/web/components/canvas/VisualManipulationTools.tsx(1134,14): error TS1005: ';' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68c219909fa48332a20d84d849fda56b